### PR TITLE
Add in retry logic for OpenAI, keep track of in-progress classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,46 @@ pipenv run flask --app ./src/main.py db migrate -m "[change description]"
 ```
 
 On next launch the database should update.
+
+## Contributing
+
+We welcome contributions to Podly! Here's how you can help:
+
+### Development Setup
+
+1. Fork the repository
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/yourusername/podly.git
+   ```
+3. Create a new branch for your feature:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+### Running Tests
+
+Before submitting a pull request, you can run the same tests that run in CI locally using:
+
+```bash
+scripts/ci.sh
+```
+
+This will run all the necessary checks including:
+- Type checking with mypy
+- Code formatting checks
+- Unit tests
+- Linting
+
+### Pull Request Process
+
+1. Ensure all tests pass locally
+2. Update the documentation if needed
+3. Create a Pull Request with a clear description of the changes
+4. Link any related issues
+
+### Code Style
+
+- We use black for code formatting
+- Type hints are required for all new code
+- Follow existing patterns in the codebase

--- a/src/podcast_processor/podcast_processor.py
+++ b/src/podcast_processor/podcast_processor.py
@@ -7,7 +7,9 @@ from typing import Any, Dict, List, Tuple
 
 import yaml
 from jinja2 import Template
-from openai import OpenAI
+from openai import OpenAI, APIError
+import time
+from typing import Optional
 from pydub import AudioSegment  # type: ignore[import-untyped]
 
 from podcast_processor.model_output import clean_and_parse_model_output
@@ -191,18 +193,19 @@ class PodcastProcessor:
     ) -> None:
         self.logger.info(f"Identifying ad segments for {task.audio_path}")
         self.logger.info(f"processing {len(transcript_segments)} transcript segments")
+
         for i in range(0, len(transcript_segments), num_segments_per_prompt):
             start = i
             end = min(i + num_segments_per_prompt, len(transcript_segments))
 
-            target_dir = f"{classification_path}/{transcript_segments[start].start}_{transcript_segments[end-1].end}"  # pylint: disable=line-too-long
-            if not os.path.exists(target_dir):
-                os.makedirs(target_dir)
-            else:
-                self.logger.info(
-                    f"Responses for segments {start} to {end} already received"
-                )
+            target_dir = f"{classification_path}/{transcript_segments[start].start}_{transcript_segments[end-1].end}"
+            os.makedirs(target_dir, exist_ok=True)
+
+            # Check if we already have a valid identification
+            if os.path.exists(f"{target_dir}/identification.txt"):
+                self.logger.info(f"Responses for segments {start} to {end} already received")
                 continue
+
             excerpts = [
                 f"[{segment.start}] {segment.text}"
                 for segment in transcript_segments[start:end]
@@ -219,28 +222,70 @@ class PodcastProcessor:
                 podcast_topic=task.podcast_description,
                 transcript="\n".join(excerpts),
             )
-            identification = self.call_model(model, system_prompt, user_prompt)
-            with open(f"{target_dir}/identification.txt", "w") as f:
-                f.write(identification)
-            with open(f"{target_dir}/prompt.txt", "w") as f:
-                f.write(user_prompt)
 
-    def call_model(self, model: str, system_prompt: str, user_prompt: str) -> str:
-        # log the request
-        self.logger.info(f"Calling model: {model}")
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            max_tokens=self.config.openai_max_tokens,
-            timeout=self.config.openai_timeout,
-        )
+            # Create a temporary file to indicate processing is in progress
+            with open(f"{target_dir}/.in_progress", "w") as f:
+                f.write("Processing")
 
-        content = response.choices[0].message.content
-        assert content is not None
-        return content
+            try:
+                identification = self.call_model(model, system_prompt, user_prompt)
+                if identification:
+                    with open(f"{target_dir}/identification.txt", "w") as f:
+                        f.write(identification)
+                    with open(f"{target_dir}/prompt.txt", "w") as f:
+                        f.write(user_prompt)
+                else:
+                    self.logger.error(f"Failed to get identification for segments {start} to {end}")
+                    # Create an empty identification file to prevent endless retries
+                    with open(f"{target_dir}/identification.txt", "w") as f:
+                        f.write('{"ad_segments": [], "confidence": 0.0}')
+            finally:
+                # Clean up the in_progress file
+                if os.path.exists(f"{target_dir}/.in_progress"):
+                    os.remove(f"{target_dir}/.in_progress")
+
+    def call_model(self, model: str, system_prompt: str, user_prompt: str, max_retries: int = 3) -> Optional[str]:
+        attempt = 0
+        last_error = None
+
+        while attempt < max_retries:
+            try:
+                self.logger.info(f"Calling model: {model} (attempt {attempt + 1}/{max_retries})")
+                response = self.client.chat.completions.create(
+                    model=model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    max_tokens=self.config.openai_max_tokens,
+                    timeout=self.config.openai_timeout,
+                )
+
+                content = response.choices[0].message.content
+                assert content is not None
+                return content
+
+            except APIError as e:
+                last_error = e
+                self.logger.error(f"OpenAI API error (attempt {attempt + 1}): {e}")
+                if e.status_code == 500:
+                    # Add exponential backoff for retries
+                    wait_time = (2 ** attempt) * 1  # 1, 2, 4 seconds
+                    time.sleep(wait_time)
+                    attempt += 1
+                    continue
+                else:
+                    # For non-500 errors, raise immediately
+                    raise
+            except Exception as e:
+                self.logger.error(f"Unexpected error calling model: {e}")
+                raise
+
+        # If we get here, we've exhausted our retries
+        self.logger.error(f"Failed to call model after {max_retries} attempts")
+        if last_error:
+            raise last_error
+        return None
 
     def get_ad_segments(
         self, segments: List[Segment], classification_path: str


### PR DESCRIPTION
I've been having some issues on my local setup whereby the OpenAI-compatible API occasionally returns 500 (eg if it's too busy to handle the request.)

The problem being that when this happens, Podly does not retry, and instead creates an empty directory under classifications. This has the effect that when it later tries to process the segments, it gets a FileNotFound error on line 254 and fails. As this has now written to storage, retrying in your podcast app results in the same thing occurring, as it assumes it has already sent that segment off and gets the FileNotFound again

This PR adds:
1) Retry logic to the OpenAI call upon receiving a 500; and
2) Adds extra error handling to the classification process, including an in-progress indicator

Happy for any feedback on this unsolicited PR; not sure if this is how you'd prefer I approached the above. Testing locally for me solves the issue I was having.