### PR TITLE
deprecate podcasts in config

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -28,10 +28,6 @@ processing:
   user_prompt_template_path: config/user_prompt.jinja
   num_segments_to_input_to_prompt: 30
 
-# enables mapping nice urls like localhost:5001/mypodcast.rss
-podcasts:
-  my_podcast.rss: "https://www.example.com/original/podcast/rss/feed.rss"
-
 output:
   fade_ms: 3000
   min_ad_segement_separation_seconds: 60

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,8 @@ app = create_app()
 
 def port_over_old_feeds() -> None:
     with app.app_context():
+        if config.podcasts is None:
+            return
         for podcast, url in config.podcasts.items():
             if not Feed.query.filter_by(rss_url=url).first():
                 feed = add_or_refresh_feed(url)

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -4,7 +4,7 @@ import os
 from typing import Dict, Optional
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ProcessingConfig(BaseModel):
@@ -27,7 +27,11 @@ class Config(BaseModel):
     openai_model: str = "gpt-4o"
     openai_timeout: int = 300
     output: OutputConfig
-    podcasts: Dict[str, str]
+    podcasts: Optional[Dict[str, str]] = Field(
+        default=None,
+        deprecated=True,
+        description="This field is deprecated and will be removed in a future version",
+    )
     processing: ProcessingConfig
     skip_processing_for_test: bool = False  # for testing
     remote_whisper: bool = False

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -30,9 +30,7 @@ def test_example_config() -> None:
             user_prompt_template_path="config/user_prompt.jinja",
             num_segments_to_input_to_prompt=30,
         ),
-        podcasts={
-            "my_podcast.rss": "https://www.example.com/original/podcast/rss/feed.rss"
-        },
+        podcasts=None,
         output=OutputConfig(
             fade_ms=3000,
             min_ad_segement_separation_seconds=60,


### PR DESCRIPTION
on discord, uRHrU0ed says

> 3) I tried commenting out the podcasts: options in the config file since it seems that that should be added through the web UI now. However, pydantic got upset and refused to start unless a valid dictionary was there. 

this PR marks this field as deprecated.