### PR TITLE
move from pydub to ffmpeg-python

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ openai-whisper = "*"
 flask-sqlalchemy = "*"
 flask-migrate = "*"
 Flask-APScheduler = "*"
+ffmpeg-python = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a97ba9bc1af244be1c1ad8f2f767ea08673ea5cc53b7e4b28180aaea34f20f4d"
+            "sha256": "7a5677284ded30eced8fb337e626190e51c83ac75f4ec9f70fe2b2101039f3a4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -234,6 +234,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==6.0.11"
         },
+        "ffmpeg-python": {
+            "hashes": [
+                "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127",
+                "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
+        },
         "filelock": {
             "hashes": [
                 "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0",
@@ -283,6 +291,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2024.12.0"
+        },
+        "future": {
+            "hashes": [
+                "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216",
+                "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.0.0"
         },
         "h11": {
             "hashes": [

--- a/src/podcast_processor/audio.py
+++ b/src/podcast_processor/audio.py
@@ -1,7 +1,7 @@
 import gc
 from typing import List, Optional, Tuple
 
-import ffmpeg
+import ffmpeg  # type: ignore[import-untyped]
 from pydub import AudioSegment  # type: ignore[import-untyped]
 
 

--- a/src/podcast_processor/audio.py
+++ b/src/podcast_processor/audio.py
@@ -1,0 +1,63 @@
+import gc
+from typing import List, Optional, Tuple
+
+import ffmpeg
+from pydub import AudioSegment  # type: ignore[import-untyped]
+
+
+def get_audio_duration_ms(file_path: str) -> Optional[int]:
+    try:
+        # Run ffmpeg.probe to get the file information
+        probe = ffmpeg.probe(file_path)
+
+        # Extract the duration from the probe data
+        format_info = probe["format"]
+        duration_seconds = float(format_info["duration"])  # Duration is in seconds
+
+        # Convert duration from seconds to milliseconds
+        duration_milliseconds = duration_seconds * 1000
+
+        return int(duration_milliseconds)
+    except ffmpeg.Error as e:
+        print("An error occurred while trying to probe the file:")
+        print(e.stderr.decode())
+        return None
+
+
+def get_ad_fade_out(
+    audio: AudioSegment, ad_start_ms: int, fade_ms: int
+) -> AudioSegment:
+    fade_out = audio[ad_start_ms : ad_start_ms + fade_ms]
+    assert isinstance(fade_out, AudioSegment)
+
+    fade_out = fade_out.fade_out(fade_ms)
+    return fade_out
+
+
+def get_ad_fade_in(audio: AudioSegment, ad_end_ms: int, fade_ms: int) -> AudioSegment:
+    fade_in = audio[ad_end_ms - fade_ms : ad_end_ms]
+    assert isinstance(fade_in, AudioSegment)
+
+    fade_in = fade_in.fade_in(fade_ms)
+    return fade_in
+
+
+def clip_segments_with_fade(
+    ad_segments_ms: List[Tuple[int, int]],
+    fade_ms: int,
+    in_path: str,
+    out_path: str,
+) -> None:
+    audio = AudioSegment.from_file(in_path)
+
+    new_audio = AudioSegment.empty()
+    last_end = 0
+    for start, end in ad_segments_ms:
+        new_audio += audio[last_end:start]
+        new_audio += get_ad_fade_out(audio, start, fade_ms)
+        new_audio += get_ad_fade_in(audio, end, fade_ms)
+        last_end = end
+        gc.collect()
+    if last_end != audio.duration_seconds * 1000:
+        new_audio += audio[last_end:]
+    new_audio.export(out_path, format="mp3")

--- a/src/podcast_processor/podcast_processor.py
+++ b/src/podcast_processor/podcast_processor.py
@@ -1,4 +1,3 @@
-import gc
 import json
 import logging
 import os

--- a/src/podcast_processor/podcast_processor.py
+++ b/src/podcast_processor/podcast_processor.py
@@ -9,10 +9,10 @@ from typing import Dict, List, Optional, Tuple, cast
 
 from jinja2 import Template
 from openai import APIError, OpenAI
-from pydub import AudioSegment  # type: ignore[import-untyped]
 
 from app import db, logger
 from app.models import Post, Transcript
+from podcast_processor.audio import clip_segments_with_fade, get_audio_duration_ms
 from podcast_processor.model_output import clean_and_parse_model_output
 from shared.config import (
     Config,
@@ -129,15 +129,22 @@ class PodcastProcessor:
             ad_segments = self.get_ad_segments(
                 transcript_segments, working_paths.classification_dir
             )
-            audio = AudioSegment.from_file(post.unprocessed_audio_path)
-            assert isinstance(audio, AudioSegment)
-            self.create_new_audio_without_ads(
-                audio=audio,
+
+            duration_ms = get_audio_duration_ms(post.unprocessed_audio_path)
+            assert duration_ms is not None
+
+            merged_ad_segments = self.merge_ad_segments(
+                duration_ms=duration_ms,
                 ad_segments=ad_segments,
                 min_ad_segment_length_seconds=self.config.output.min_ad_segment_length_seconds,
-                min_ad_segement_separation_seconds=self.config.output.min_ad_segement_separation_seconds,  # pylint: disable=line-too-long
+                min_ad_segment_separation_seconds=self.config.output.min_ad_segement_separation_seconds,  # pylint: disable=line-too-long
+            )
+            clip_segments_with_fade(
+                in_path=post.unprocessed_audio_path,
+                ad_segments_ms=merged_ad_segments,
                 fade_ms=self.config.output.fade_ms,
-            ).export(processed_audio_path, format="mp3")
+                out_path=processed_audio_path,
+            )
             self.logger.info(f"Processing podcast: {post} complete")
             post.processed_audio_path = processed_audio_path
             db.session.commit()
@@ -359,33 +366,17 @@ class PodcastProcessor:
 
         return ad_segments
 
-    def get_ad_fade_out(
-        self, audio: AudioSegment, ad_start_ms: int, fade_ms: int
-    ) -> AudioSegment:
-        fade_out = audio[ad_start_ms : ad_start_ms + fade_ms]
-        assert isinstance(fade_out, AudioSegment)
-
-        fade_out = fade_out.fade_out(fade_ms)
-        return fade_out
-
-    def get_ad_fade_in(
-        self, audio: AudioSegment, ad_end_ms: int, fade_ms: int
-    ) -> AudioSegment:
-        fade_in = audio[ad_end_ms - fade_ms : ad_end_ms]
-        assert isinstance(fade_in, AudioSegment)
-
-        fade_in = fade_in.fade_in(fade_ms)
-        return fade_in
-
-    def create_new_audio_without_ads(
+    def merge_ad_segments(
         self,
         *,
-        audio: AudioSegment,
+        duration_ms: int,
+        min_ad_segment_length_seconds: float,
+        min_ad_segment_separation_seconds: float,
         ad_segments: List[Tuple[float, float]],
-        min_ad_segment_length_seconds: int,
-        min_ad_segement_separation_seconds: int,
-        fade_ms: int = 5000,
-    ) -> AudioSegment:
+    ) -> List[Tuple[int, int]]:
+
+        audio_duration_seconds = 1000 * duration_ms
+
         self.logger.info(
             f"Creating new audio with ads segments removed between: {ad_segments}"
         )
@@ -394,7 +385,7 @@ class PodcastProcessor:
         i = 0
         while i < len(ad_segments) - 1:
             if (
-                ad_segments[i][1] + min_ad_segement_separation_seconds
+                ad_segments[i][1] + min_ad_segment_separation_seconds
                 >= ad_segments[i + 1][0]
             ):
                 ad_segments[i] = (ad_segments[i][0], ad_segments[i + 1][1])
@@ -411,28 +402,17 @@ class PodcastProcessor:
         # whisper sometimes drops the last bit of the transcript & this can lead
         # to end-roll not being entirely removed, so bump the ad segment to the
         # end of the audio if it's close enough
-        if len(ad_segments) > 0:
-            if (
-                audio.duration_seconds - ad_segments[-1][1]
-                < min_ad_segement_separation_seconds
-            ):
-                ad_segments[-1] = (ad_segments[-1][0], audio.duration_seconds)
+        if len(ad_segments) > 0 and (
+            audio_duration_seconds - ad_segments[-1][1]
+            < min_ad_segment_separation_seconds
+        ):
+            ad_segments[-1] = (ad_segments[-1][0], audio_duration_seconds)
         self.logger.info(f"Joined ad segments into: {ad_segments}")
 
         ad_segments_ms = [
             (int(start * 1000), int(end * 1000)) for start, end in ad_segments
         ]
-        new_audio = AudioSegment.empty()
-        last_end = 0
-        for start, end in ad_segments_ms:
-            new_audio += audio[last_end:start]
-            new_audio += self.get_ad_fade_out(audio, start, fade_ms)
-            new_audio += self.get_ad_fade_in(audio, end, fade_ms)
-            last_end = end
-            gc.collect()
-        if last_end != audio.duration_seconds * 1000:
-            new_audio += audio[last_end:]
-        return new_audio
+        return ad_segments_ms
 
 
 class ProcessorException(Exception):


### PR DESCRIPTION
PYdub is very memory inefficient, to the point of causing OOMs on my machine when clipping longer podcasts. See  https://github.com/jdrbc/podly_pure_podcasts/issues/57


Fixes https://github.com/jdrbc/podly_pure_podcasts/issues/57