### PR TITLE
minor UI enhancements

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -107,10 +107,22 @@ def feed_item(post: Post) -> PyRSS2Gen.RSSItem:
     https://github.com/Podcast-Standards-Project/PSP-1-Podcast-RSS-Specification?tab=readme-ov-file#required-item-elements
     """
 
-    audio_url = (config.server if config.server is not None else "") + url_for(
+    server_prefix = config.server if config.server is not None else ""
+
+    audio_url = server_prefix + url_for(
         "main.download_post",
         p_guid=post.guid,
         _external=config.server is None,
+    )
+
+    post_details_url = server_prefix + url_for(
+        "main.post_page",
+        p_guid=post.guid,
+        _external=config.server is None,
+    )
+
+    description = (
+        f'{post.description}\n<p><a href="{post_details_url}">Podly Post Page</a></p>'
     )
 
     item = PyRSS2Gen.RSSItem(
@@ -120,7 +132,7 @@ def feed_item(post: Post) -> PyRSS2Gen.RSSItem:
             type="audio/mpeg",
             length=post.audio_len_bytes(),
         ),
-        description=post.description,
+        description=description,
         guid=post.guid,
         pubDate=(
             post.release_date.strftime("%a, %d %b %Y %H:%M:%S %z")

--- a/src/app/templates/post.html
+++ b/src/app/templates/post.html
@@ -1,4 +1,20 @@
-<table border="1">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ post.title }}</title>
+</head>
+<body>
+    <a href="{{ url_for('main.index') }}">
+        <img
+            src="{{ url_for('static', filename='images/logos/logo_with_text.png') }}"
+            alt="Podly Logo"
+            style="width: 300px"
+        />
+    </a>
+  
+  <table border="1">
     <thead>
         <tr>
             <th>Name</th>
@@ -52,7 +68,11 @@
         </tr>
         <tr>
             <td>whitelisted</td>
-            <td>{{ post.whitelisted }}</td>
+            <td>{{ post.whitelisted }}
+<button onclick="setWhitelist('{{ post.guid }}', {{ post.whitelisted | lower }})">
+ Toggle Whitelist
+</button>
+			</td>
         </tr>
         <tr>
             <td>Transcript</td>
@@ -73,3 +93,17 @@
         </tr>
     </tbody>
 </table>
+<script>
+      function setWhitelist(postGuid, old_val) {
+        console.log("set whitelist for post: " + postGuid + " to: " + !old_val);
+        const url = "{{ url_for('main.set_whitelist', p_guid='0', val=False)}}"
+          .replace("0", postGuid)
+          .replace("/False", "/" + !old_val);
+        fetch(url)
+          .then((_) => window.location.reload())
+          .catch((error) => console.error("Error:", error));
+      }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
1. inject a link to the podly post page into the podcast description. this makes it easy to go from podcast app -> relevant podly page to view transcript / toggle whitelist status.
1. add whitelist toggle button to post page
2. add link from post page back to the main page for easier navigation
3. change the title of the post page to be the title of the post