### PR TITLE
Pass feed image metadata through to client

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -153,12 +153,13 @@ def feed_item(post: Post) -> PyRSS2Gen.RSSItem:
 def generate_feed_xml(feed: Feed) -> Any:
     logger.info(f"Generating XML for feed with ID: {feed.id}")
     items = [feed_item(post) for post in feed.posts]  # type: ignore[attr-defined]
+    link = url_for("main.get_feed", f_id=feed.id, _external=True)
     rss_feed = PyRSS2Gen.RSS2(
         title="[podly] " + feed.title,
-        link=url_for("main.get_feed", f_id=feed.id, _external=True),
+        link=link,
         description=feed.description,
         lastBuildDate=datetime.datetime.now(),
-        image=PyRSS2Gen.Image(feed.image_url, feed.title, feed.rss_url),
+        image=PyRSS2Gen.Image(url=feed.image_url, title=feed.title, link=link),
         items=items,
     )
     logger.info(f"XML generated for feed with ID: {feed.id}")

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -18,6 +18,7 @@ class Feed(db.Model):  # type: ignore[name-defined, misc]
     description = db.Column(db.Text)
     author = db.Column(db.Text)
     rss_url = db.Column(db.Text, unique=True, nullable=False)
+    image_url = db.Column(db.Text)
 
     posts = db.relationship(
         "Post", backref="feed", lazy=True, order_by="Post.release_date.desc()"

--- a/src/migrations/versions/ded4b70feadb_add_image_metadata_to_feed.py
+++ b/src/migrations/versions/ded4b70feadb_add_image_metadata_to_feed.py
@@ -1,0 +1,28 @@
+"""Add image metadata to feed
+
+Revision ID: ded4b70feadb
+Revises: 6e0e16299dcb
+Create Date: 2025-03-01 14:30:20.177608
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ded4b70feadb"
+down_revision = "6e0e16299dcb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("feed", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("image_url", sa.Text(), nullable=True))
+    pass
+
+
+def downgrade():
+    with op.batch_alter_table("feed", schema=None) as batch_op:
+        batch_op.drop_column("image_url")
+    pass


### PR DESCRIPTION
Pass through the album artwork from the source podcast feed; this makes it much easier to disambiguate the feeds in podcast clients.  