### PR TITLE
Fix bug when duration is missing

### DIFF
--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -43,7 +43,8 @@ def post_page(p_guid: str) -> flask.Response:
 
     # the spec defines some allowed tags. strip other for security
     # https://github.com/Podcast-Standards-Project/PSP-1-Podcast-RSS-Specification?tab=readme-ov-file#item-description
-    allowed_tags = ["p", "ol", "ul", "li", "a", "b", "i", "strong", "em"]
+    spec_tags = ["p", "ol", "ul", "li", "a", "b", "i", "strong", "em"]
+    allowed_tags = spec_tags + ["br"]
     allowed_attributes = {"a": ["href", "title"]}
     clean_description = bleach.clean(
         post.description,

--- a/src/app/templates/post.html
+++ b/src/app/templates/post.html
@@ -69,6 +69,7 @@
 		<tr>
 			<td>Duration</td>
 			<td>
+			{% if post and post.duration is not none %}
 				{% set hours = post.duration // 3600 %}
 				{% set minutes = (post.duration % 3600) // 60 %}
 				{% set seconds = post.duration % 60 %}
@@ -78,6 +79,9 @@
 				{% else %}
 					{{ minutes }}m {{ seconds }}s
 				{% endif %}
+			{% else %}
+				No duration available
+			{% endif %}
 			</td>
 		</tr>
         <tr>

--- a/src/app/templates/post.html
+++ b/src/app/templates/post.html
@@ -27,6 +27,10 @@
             <td>{{ post.feed.title }}</td>
         </tr>
         <tr>
+            <td>Post Title</td>
+            <td>{{ post.title }}</td>
+        </tr>
+        <tr>
             <td>Feed ID</td>
             <td>{{ post.feed_id }}</td>
         </tr>
@@ -45,10 +49,6 @@
         <tr>
             <td>Podly Download URL</td>
 			<td><a href="{{ url_for('main.download_post', p_guid=post.guid) }}" target="_blank">{{ url_for('main.download_post', p_guid=post.guid) }}</a></td>
-        </tr>
-        <tr>
-            <td>title</td>
-            <td>{{ post.title }}</td>
         </tr>
         <tr>
             <td>unprocessed_audio_path</td>


### PR DESCRIPTION
fix bug introduced in https://github.com/jdrbc/podly_pure_podcasts/pull/68

if the duration field on post is missing the post page would fail to render

also allow `<br>` tag in post description. it's not in the spec, but I noticed a few of my podcasts use it