### PR TITLE
fixing scheduler crash if image metadata was missing

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -23,9 +23,12 @@ def refresh_feed(feed: Feed) -> None:
     logger.info(f"Refreshing feed with ID: {feed.id}")
     feed_data = fetch_feed(feed.rss_url)
 
-    if feed.image_url != feed_data.feed.image.href:
-        feed.image_url = feed_data.feed.image.href
-        db.session.add(feed)
+    image_info = feed_data.feed.get("image")
+    if image_info and "href" in image_info:
+        new_image_url = image_info["href"]
+        if feed.image_url != new_image_url:
+            feed.image_url = new_image_url
+            db.session.add(feed)
 
     existing_posts = {post.guid for post in feed.posts}  # type: ignore[attr-defined]
     oldest_post = min(


### PR DESCRIPTION
Error was: <code>pipenv[272675]: ERROR [global_logger] Error in scheduled job 'refresh_all_feeds': object has no attribute 'image'</code>

Prior code assumes that the parsed feed data always includes an image attribute (with a nested href), but some RSS feeds may not provide image metadata. When a feed doesn’t include an image, trying to access feed_data.feed.image raises an AttributeError.