### PR TITLE
Add configurable timeout and chunksize for (remote) Whisper

### DIFF
--- a/config/config_remote_whisper.yml.example
+++ b/config/config_remote_whisper.yml.example
@@ -41,5 +41,5 @@ whisper:
   api_key: this_is_fake
   # Optional whisper settings
   # language: "en"
-  # timeout: 60 # in seconds
-  # chunksize: 60 # in megabyte
+  # timeout_sec: 60
+  # chunksize_mb: 60

--- a/config/config_remote_whisper.yml.example
+++ b/config/config_remote_whisper.yml.example
@@ -34,7 +34,12 @@ output:
   min_confidence: 0.8
 
 whisper:
+  # Required whisper settings
   whisper_type: remote
   model: whisper-2
   base_url: http://localhost/v99
   api_key: this_is_fake
+  # Optional whisper settings
+  # language: "en"
+  # timeout: 60 # in seconds
+  # chunksize: 60 # in megabyte

--- a/config/config_remote_whisper.yml.example
+++ b/config/config_remote_whisper.yml.example
@@ -41,5 +41,5 @@ whisper:
   api_key: this_is_fake
   # Optional whisper settings
   # language: "en"
-  # timeout_sec: 60
-  # chunksize_mb: 60
+  # timeout_sec: 600 # http timeout for the whisper connection
+  # chunksize_mb: 24 # File size in MB for audio chunks uploaded sequentially to Whisper

--- a/config/config_remote_whisper.yml.example
+++ b/config/config_remote_whisper.yml.example
@@ -37,9 +37,9 @@ whisper:
   # Required whisper settings
   whisper_type: remote
   model: whisper-2
-  base_url: http://localhost/v99
   api_key: this_is_fake
   # Optional whisper settings
+  # base_url: http://localhost/v99 # Default is the OpenAI Whisper service
   # language: "en"
-  # timeout_sec: 600 # http timeout for the whisper connection
+  # timeout_sec: 600 # HTTP timeout in seconds for the Whisper connection
   # chunksize_mb: 24 # File size in MB for audio chunks uploaded sequentially to Whisper

--- a/src/podcast_processor/transcribe.py
+++ b/src/podcast_processor/transcribe.py
@@ -96,7 +96,7 @@ class RemoteWhisperTranscriber(Transcriber):
         self.openai_client = OpenAI(
             base_url=config.base_url,
             api_key=config.api_key,
-            timeout=config.timeout,
+            timeout=config.timeout_sec,
         )
 
     def transcribe(self, audio_file_path: str) -> List[Segment]:
@@ -106,7 +106,7 @@ class RemoteWhisperTranscriber(Transcriber):
         chunks = split_audio(
             Path(audio_file_path),
             Path(audio_chunk_path),
-            self.config.chunksize * 1024 * 1024,
+            self.config.chunksize_mb * 1024 * 1024,
         )
 
         all_segments: List[TranscriptionSegment] = []

--- a/src/podcast_processor/transcribe.py
+++ b/src/podcast_processor/transcribe.py
@@ -96,6 +96,7 @@ class RemoteWhisperTranscriber(Transcriber):
         self.openai_client = OpenAI(
             base_url=config.base_url,
             api_key=config.api_key,
+            timeout=config.timeout,
         )
 
     def transcribe(self, audio_file_path: str) -> List[Segment]:
@@ -103,7 +104,9 @@ class RemoteWhisperTranscriber(Transcriber):
         audio_chunk_path = audio_file_path + "_parts"
 
         chunks = split_audio(
-            Path(audio_file_path), Path(audio_chunk_path), 24 * 1024 * 1024
+            Path(audio_file_path),
+            Path(audio_chunk_path),
+            self.config.chunksize * 1024 * 1024,
         )
 
         all_segments: List[TranscriptionSegment] = []

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -33,6 +33,8 @@ class RemoteWhisperConfig(BaseModel):
     api_key: str
     language: str = "en"
     model: str = "whisper-1"  # openai model, use your own maybe
+    timeout: int = 600
+    chunksize: int = 24
 
 
 class LocalWhisperConfig(BaseModel):

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -33,8 +33,8 @@ class RemoteWhisperConfig(BaseModel):
     api_key: str
     language: str = "en"
     model: str = "whisper-1"  # openai model, use your own maybe
-    timeout: int = 600
-    chunksize: int = 24
+    timeout_sec: int = 600
+    chunksize_mb: int = 24
 
 
 class LocalWhisperConfig(BaseModel):

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -75,7 +75,7 @@ def test_remote_whisper_example_config() -> None:
         openai_base_url=None,
         whisper=RemoteWhisperConfig(
             model="whisper-2",
-            base_url="http://localhost/v99",
+            base_url="https://api.openai.com/v1",
             api_key="this_is_fake",
         ),
         automatically_whitelist_new_episodes=True,


### PR DESCRIPTION
This pull request introduces the ability to configure two important parameters for remote Whisper:

1. **HTTP Timeout**: Allows users to set a custom timeout value for HTTP requests to the remote Whisper service.
2. **Chunksize**: Adds the option to define the file size at which audio files are split into smaller parts for processing.

Additionally, the example configuration file has been updated to include:
- The missing language option with default value.
- Default values for both `timeout` and `chunksize`.

Default values in the code and in the config are the currently used values.

### Why this is important:
Both options are essential for handling slow Whisper services. Increasing the timeout and adjusting chunksize help prevent failures caused by long processing times, such as overloading, slow systems, or large models.

Let me know if you have any questions or need further clarification!

Fixes #78 