### PR TITLE
Fix missing duration and have show them as integer

### DIFF
--- a/src/app/templates/post.html
+++ b/src/app/templates/post.html
@@ -70,15 +70,11 @@
 			<td>Duration</td>
 			<td>
 			{% if post and post.duration is not none %}
-				{% set hours = post.duration // 3600 %}
-				{% set minutes = (post.duration % 3600) // 60 %}
-				{% set seconds = post.duration % 60 %}
+				{% set hours = (post.duration // 3600) | int %}
+				{% set minutes = ((post.duration % 3600) // 60) | int %}
+				{% set seconds = (post.duration % 60 | round(0)) | int %}
 
-				{% if hours > 0 %}
-					{{ hours }}h {{ minutes }}m {{ seconds }}s
-				{% else %}
-					{{ minutes }}m {{ seconds }}s
-				{% endif %}
+				{{ (hours > 0 and (hours|string + 'h ') or '') }}{{ minutes }}m {{ seconds }}s
 			{% else %}
 				No duration available
 			{% endif %}

--- a/src/podcast_processor/podcast_processor.py
+++ b/src/podcast_processor/podcast_processor.py
@@ -133,6 +133,7 @@ class PodcastProcessor:
 
             duration_ms = get_audio_duration_ms(post.unprocessed_audio_path)
             assert duration_ms is not None
+            post.duration = duration_ms / 1000.0  # Store duration in seconds
 
             merged_ad_segments = self.merge_ad_segments(
                 duration_ms=duration_ms,


### PR DESCRIPTION
Added the missing duration to post to put it in DB.
Also changed the output to looks better, because without it displayed like 10.0m 5.436363462563s.
Depends on #91 and partially closes #79 