### PR TITLE
Update various docker build components w/ newer cuda version and with…

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,10 +20,11 @@ services:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:--1}
-    # restart: unless-stopped
-    # healthcheck:
-    #   test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')"]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3
-    #   start_period: 10s
+    restart: unless-stopped
+    healthcheck:
+       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/')"]
+       interval: 30s
+       timeout: 10s
+       retries: 3
+       start_period: 10s
+

--- a/run_podly_docker.sh
+++ b/run_podly_docker.sh
@@ -7,7 +7,7 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 # Central configuration defaults
-CUDA_VERSION="12.1"
+CUDA_VERSION="12.4.1"
 CPU_BASE_IMAGE="python:3.11-slim"
 GPU_BASE_IMAGE="nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu22.04"
 
@@ -131,3 +131,4 @@ else
         docker compose $COMPOSE_FILES up
     fi
 fi 
+


### PR DESCRIPTION
… python3.

The prior path torch was installed with (https://download.pytorch.org/whl) no longer seems like it has the same format.

Corrects broken build script - Tested with:
```
./run_podly_docker.sh --build
./run_podly_docker.sh -d

CONTAINER ID   IMAGE                  COMMAND                  CREATED          STATUS                    PORTS                                                                                                                                                                  NAMES
1deab987af9e   podly-app              "/docker-entrypoint.…"   11 minutes ago   Up 11 minutes (healthy)   0.0.0.0:5001->5001/tcp, [::]:5001->5001/tcp  
```