### PR TITLE
Initial amdgpu/rocm support

### DIFF
--- a/compose.rocm.yml
+++ b/compose.rocm.yml
@@ -1,0 +1,20 @@
+services:
+  backend:
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    environment:
+      # Don't ask me why this is needed for ROCM. See
+      # https://github.com/openai/whisper/discussions/55#discussioncomment-3714528
+      - HSA_OVERRIDE_GFX_VERSION=10.3.0
+    security_opt:
+      - seccomp=unconfined
+# This would be ideal. Not currently supported, apparently. Or I just wasn't able to figure out the driver arg.
+# Tried: amdgpu, amd, rocm
+#    deploy:
+#      resources:
+#        reservations:
+#          devices:
+#            - capabilities: [gpu]
+#              driver: "amdgpu"
+#              count: 1

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,8 @@ services:
         - BASE_IMAGE=${BASE_IMAGE:-python:3.11-slim}
         - CUDA_VERSION=${CUDA_VERSION:-12.1}
         - USE_GPU=${USE_GPU:-false}
+        - USE_GPU_NVIDIA=${USE_GPU_NVIDIA:-false}
+        - USE_GPU_AMD=${USE_GPU_AMD:-false}
     ports:
       - 5002:5002
     environment:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -5,7 +5,10 @@ FROM ${BASE_IMAGE} AS base
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ARG CUDA_VERSION=12.4.1
+ARG ROCM_VERSION=6.4
 ARG USE_GPU=false
+ARG USE_GPU_NVIDIA=${USE_GPU}
+ARG USE_GPU_AMD=false
 
 WORKDIR /app
 
@@ -19,6 +22,7 @@ RUN if [ -f /etc/debian_version ]; then \
         gosu \
         python3-pip \
         python3 \
+        && if [ $(python3 --version | awk '{print $2}' | cut -d '.' -f2) -lt 11 ]; then apt-get install -y python3-tomli; fi \
         && apt-get clean && \
         rm -rf /var/lib/apt/lists/* ; \
     fi
@@ -31,9 +35,11 @@ RUN pip3 install --no-cache-dir pipenv && \
     pipenv install --deploy --system --dev
 
 # Install PyTorch with CUDA support if using NVIDIA image
-RUN if [ "${USE_GPU}" = "true" ]; then \
+RUN if [ "${USE_GPU}" = "true" ] || [ "${USE_GPU_NVIDIA}" = "true" ]; then \
         pip install nvidia-cudnn-cu12; \
         pip install torch; \
+    elif [ "${USE_GPU_AMD}" = "true" ]; then \
+        pip install torch --index-url https://download.pytorch.org/whl/rocm${ROCM_VERSION}; \
     else \
         pip install torch --index-url https://download.pytorch.org/whl/cpu; \
     fi

--- a/react-tailwind-ui.md
+++ b/react-tailwind-ui.md
@@ -152,6 +152,8 @@ services:
         - BASE_IMAGE=${BASE_IMAGE:-python:3.11-slim}
         - CUDA_VERSION=${CUDA_VERSION:-12.1}
         - USE_GPU=${USE_GPU:-false}
+        - USE_GPU_NVIDIA=${USE_GPU_NVIDIA:-false}
+        - USE_GPU_RADEON=${USE_GPU_RADEON:-false}
     ports:
       - 5002:5002
     environment:


### PR DESCRIPTION
This adds the ability to run whisper via ROCM (amdgpu) acceleration.

The important notes:
* ROCM and CUDA docker images use python3.10 instead of python3.11. This means I had to "manually" install `tomli`.
* I could not get `deploy.resources.reservations.devices` to work for amd. I also wasn't able to find anything easily with duckduckgo.
* Converted `USE_GPU` to `USE_GPU_NVIDIA`, kept `USE_GPU` around for backwards compatibility.