### PR TITLE
Refactor frontend configuration to define backend API url as environment variable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,8 +128,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VITE_API_URL=http://localhost:5002
           # Temporarily disabled due to GitHub Actions Cache service outage
           # cache-from: type=gha
           # cache-to: type=gha,mode=max

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -10,9 +10,6 @@ RUN npm ci
 # Copy source code
 COPY frontend/ ./
 
-# Build the application with environment variable
-ARG VITE_API_URL
-ENV VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
 RUN npm run build
 
 # Production stage
@@ -27,5 +24,9 @@ COPY docker/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 # Expose port 80
 EXPOSE 80
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"] 
+# Copy the frontend startup script
+COPY docker-entrypoint-frontend.sh /docker-entrypoint-frontend.sh
+RUN chmod +x /docker-entrypoint-frontend.sh
+
+# Execute the startup script
+CMD ["/docker-entrypoint-frontend.sh"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Here's how it works:
 - Podly removes the ad segments
 - Podly delivers the ad-free version of the podcast to you
 
-
 ## How To Run
 
 For detailed setup instructions, see our [beginner's guide](docs/how_to_run_beginners.md).
@@ -32,17 +31,19 @@ For detailed setup instructions, see our [beginner's guide](docs/how_to_run_begi
 ### Quick Start - No Docker
 
 1. Install dependencies:
+
    ```shell
    # Install ffmpeg
    sudo apt install ffmpeg  # Ubuntu/Debian
    # or
    brew install ffmpeg      # macOS
-   
+
    # Install Python and Node.js dependencies
    pip install pipenv
    ```
 
 2. Set up configuration:
+
    ```shell
    # Copy example config and edit
    cp config/config.yml.example config/config.yml
@@ -50,18 +51,20 @@ For detailed setup instructions, see our [beginner's guide](docs/how_to_run_begi
    ```
 
 3. Run Podly:
+
    ```shell
    # Make script executable
    chmod +x run_podly.sh
-   
+
    # Start Podly (interactive mode)
    ./run_podly.sh
-   
+
    # Or start in background mode
    ./run_podly.sh -b
    ```
 
 The script will automatically:
+
 - Set up Python virtual environment
 - Install frontend dependencies
 - Configure environment variables from config.yml
@@ -70,12 +73,14 @@ The script will automatically:
 ### Quick Start - With Docker
 
 1. Set up your configuration:
+
    ```bash
    cp config/config.yml.example config/config.yml
    # Edit config.yml with your settings
    ```
 
 2. Run Podly with Docker:
+
    ```bash
    # Make the script executable first
    chmod +x run_podly_docker.sh
@@ -84,18 +89,19 @@ The script will automatically:
 
    This will automatically detect if you have an NVIDIA GPU and use it for acceleration.
 
-
 ### Manual Setup
 
 If you prefer to run components separately:
 
 1. Install Python dependencies:
+
    ```shell
    pipenv --python 3.11
    pipenv install
    ```
 
 2. Install frontend dependencies:
+
    ```shell
    cd frontend
    npm install
@@ -103,12 +109,14 @@ If you prefer to run components separately:
    ```
 
 3. Set up environment variables:
+
    ```shell
    # Set API URL based on your config.yml
    export VITE_API_URL="http://localhost:5002"  # or your server URL
    ```
 
 4. Start backend:
+
    ```shell
    pipenv run python src/main.py
    ```
@@ -235,12 +243,14 @@ Podly can be run in Docker with support for both NVIDIA GPU and non-NVIDIA envir
 ### Quick Start with Docker
 
 1. Set up your configuration:
+
    ```bash
    cp config/config.yml.example config/config.yml
    # Edit config.yml with your settings
    ```
 
 2. Run Podly with Docker:
+
    ```bash
    # Make the script executable first
    chmod +x run_podly_docker.sh
@@ -252,10 +262,11 @@ Podly can be run in Docker with support for both NVIDIA GPU and non-NVIDIA envir
 ### Docker vs Native
 
 - **Use Docker** (`./run_podly_docker.sh`) if you:
+
   - Want containerized deployment
   - Need GPU acceleration for Whisper
   - Prefer isolated environments
-  
+
 - **Use Native** (`./run_podly.sh`) if you:
   - Want faster development iteration
   - Prefer direct access to logs and debugging
@@ -299,12 +310,14 @@ You can use these command-line options with the run script:
 ### Development vs Production Modes
 
 **Development Mode** (default):
+
 - Uses local Docker builds
 - Requires rebuilding after code changes: `./run_podly_docker.sh --dev`
 - Mounts only essential directories (config, input/output, database)
 - Good for: development, testing, customization
 
 **Production Mode**:
+
 - Uses pre-built images from GitHub Container Registry
 - No building required - images are pulled automatically
 - Same volume mounts as development
@@ -314,24 +327,48 @@ You can use these command-line options with the run script:
 # Start with existing local containers
 ./run_podly_docker.sh
 
-# Rebuild and start after making code changes  
+# Rebuild and start after making code changes
 ./run_podly_docker.sh --dev
 
 # Use published images (no local building required)
 ./run_podly_docker.sh --production
 ```
 
+### Docker Environment Configuration
+
+The Docker setup uses runtime environment variables that can be configured when starting the containers:
+
+**Frontend API URL Configuration**:
+
+- `VITE_API_URL`: Sets the backend API URL for the frontend (default: `http://localhost:5002`)
+- Can be customized at runtime without rebuilding the image
+
+```bash
+# Example: Run with custom API URL
+VITE_API_URL=http://your-server.com:5002 ./run_podly_docker.sh
+
+# Or set in Docker Compose environment:
+docker compose up -e VITE_API_URL=http://your-server.com:5002
+```
+
+**Other Environment Variables**:
+
+- `PUID`/`PGID`: User/group IDs for file permissions (automatically set by run script)
+- `CUDA_VISIBLE_DEVICES`: GPU device selection for CUDA acceleration
+- `CORS_ORIGINS`: Backend CORS configuration
+
 ## FAQ
 
 Q: What does "whitelisted" mean in the UI?
 
-A: It means an episode is eligible for download and ad removal. By default, new episodes are automatically whitelisted (```automatically_whitelist_new_episodes```), and only a limited number of old episodes are auto-whitelisted (```number_of_episodes_to_whitelist_from_archive_of_new_feed```). This helps control costs by limiting how many episodes are processed. You can adjust these settings in your config.yml for more manual control.
-  
+A: It means an episode is eligible for download and ad removal. By default, new episodes are automatically whitelisted (`automatically_whitelist_new_episodes`), and only a limited number of old episodes are auto-whitelisted (`number_of_episodes_to_whitelist_from_archive_of_new_feed`). This helps control costs by limiting how many episodes are processed. You can adjust these settings in your config.yml for more manual control.
+
 Q: How can I enable whisper GPU acceleration?
 
 A: There are two ways to enable GPU acceleration:
 
-1. **Using Docker**: 
+1. **Using Docker**:
+
    - Use the provided Docker setup with `run_podly_docker.sh` which automatically detects and uses NVIDIA GPUs if available
    - You can force GPU mode with `./run_podly_docker.sh --gpu` or force CPU mode with `./run_podly_docker.sh --cpu`
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -20,6 +20,8 @@ services:
     image: ghcr.io/jdrbc/podly_pure_podcasts-frontend:${FRONTEND_VARIANT:-latest}
     ports:
       - 5001:80
+    environment:
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
     depends_on:
       - backend
     restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -30,16 +30,22 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.frontend
-      args:
-        - VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
     ports:
       - 5001:80
+    environment:
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
     depends_on:
       - backend
     restart: unless-stopped
     healthcheck:
-       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/')"]
-       interval: 30s
-       timeout: 10s
-       retries: 3
-       start_period: 10s
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:5001/')",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/docker-entrypoint-frontend.sh
+++ b/docker-entrypoint-frontend.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Default API URL if not provided
+VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
+
+echo "Configuring frontend with API URL: $VITE_API_URL"
+
+# Find and replace the API URL placeholder in built JavaScript files
+# We'll replace any occurrence of the placeholder with the runtime environment variable
+find /usr/share/nginx/html -name "*.js" -type f -exec sed -i "s|__VITE_API_URL_PLACEHOLDER__|$VITE_API_URL|g" {} \;
+
+echo "Frontend configuration complete"
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,31 +24,54 @@ export default tseslint.config({
   languageOptions: {
     // other options...
     parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      project: ["./tsconfig.node.json", "./tsconfig.app.json"],
       tsconfigRootDir: import.meta.dirname,
     },
   },
-})
+});
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from "eslint-plugin-react-x";
+import reactDom from "eslint-plugin-react-dom";
 
 export default tseslint.config({
   plugins: {
     // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
+    "react-x": reactX,
+    "react-dom": reactDom,
   },
   rules: {
     // other rules...
     // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
+    ...reactX.configs["recommended-typescript"].rules,
     ...reactDom.configs.recommended.rules,
   },
-})
+});
 ```
+
+## Environment Configuration
+
+This frontend supports runtime configuration through environment variables:
+
+### Development Mode
+
+When running with `npm run dev`, you can configure the API URL using:
+
+- `.env` file: `VITE_API_URL=http://localhost:5002`
+- Environment variable: `VITE_API_URL=http://localhost:5002 npm run dev`
+
+### Production/Docker Mode
+
+When running in Docker, the API URL is configured at container startup time through the `VITE_API_URL` environment variable. No rebuild is required to change the API URL.
+
+Example:
+
+```bash
+docker run -e VITE_API_URL=http://production-server:5002 podly-frontend
+```
+
+The frontend will automatically use the correct API URL based on the environment configuration.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { Feed, Episode } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5002';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '__VITE_API_URL_PLACEHOLDER__';
 
 const api = axios.create({
   baseURL: API_BASE_URL,
@@ -76,7 +76,7 @@ export const feedsApi = {
     const response = await api.get(`/api/posts/${guid}/download`, {
       responseType: 'blob',
     });
-    
+
     const blob = new Blob([response.data], { type: 'audio/mpeg' });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -93,7 +93,7 @@ export const feedsApi = {
     const response = await api.get(`/api/posts/${guid}/download/original`, {
       responseType: 'blob',
     });
-    
+
     const blob = new Blob([response.data], { type: 'audio/mpeg' });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -280,4 +280,4 @@ export const feedsApi = {
   getEpisodeOriginalDownloadUrl: (guid: string): string => {
     return feedsApi.getPostOriginalDownloadUrl(guid);
   },
-}; 
+};


### PR DESCRIPTION
Now that there are pre-built docker images, we need a way to specify the backend API url outside of the build process.

This PR moves this from a build argument to an environment variable. If no environment variable is specified, the existing default of http://localhost:5002 is used.

This should help resolve this issue: https://github.com/jdrbc/podly_pure_podcasts/issues/106