### PR TITLE
Fix for VITE_API_URL environment variable working with Vite

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 services:
   backend:
     container_name: podly_backend
-    image: ghcr.io/kris-anderson/podly_pure_podcasts-backend:${BACKEND_VARIANT:-latest}
+    image: ghcr.io/jdrbc/podly_pure_podcasts-backend:${BACKEND_VARIANT:-latest}
     volumes:
       - ./config:/app/config
       - ./in:/app/in
@@ -17,7 +17,7 @@ services:
 
   frontend:
     container_name: podly_frontend
-    image: ghcr.io/kris-anderson/podly_pure_podcasts-frontend:${FRONTEND_VARIANT:-latest}
+    image: ghcr.io/jdrbc/podly_pure_podcasts-frontend:${FRONTEND_VARIANT:-latest}
     ports:
       - 5001:80
     environment:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 services:
   backend:
     container_name: podly_backend
-    image: ghcr.io/jdrbc/podly_pure_podcasts-backend:${BACKEND_VARIANT:-latest}
+    image: ghcr.io/kris-anderson/podly_pure_podcasts-backend:${BACKEND_VARIANT:-latest}
     volumes:
       - ./config:/app/config
       - ./in:/app/in
@@ -17,7 +17,7 @@ services:
 
   frontend:
     container_name: podly_frontend
-    image: ghcr.io/jdrbc/podly_pure_podcasts-frontend:${FRONTEND_VARIANT:-latest}
+    image: ghcr.io/kris-anderson/podly_pure_podcasts-frontend:${FRONTEND_VARIANT:-latest}
     ports:
       - 5001:80
     environment:
@@ -26,8 +26,16 @@ services:
       - backend
     restart: unless-stopped
     healthcheck:
-       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80/"]
-       interval: 30s
-       timeout: 10s
-       retries: 3
-       start_period: 10s
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/docker-entrypoint-frontend.sh
+++ b/docker-entrypoint-frontend.sh
@@ -6,9 +6,8 @@ VITE_API_URL=${VITE_API_URL:-http://localhost:5002}
 
 echo "Configuring frontend with API URL: $VITE_API_URL"
 
-# Find and replace the API URL placeholder in built JavaScript files
-# We'll replace any occurrence of the placeholder with the runtime environment variable
-find /usr/share/nginx/html -name "*.js" -type f -exec sed -i "s|__VITE_API_URL_PLACEHOLDER__|$VITE_API_URL|g" {} \;
+# Replace the API URL placeholder in the runtime config file
+sed -i "s|__VITE_API_URL_PLACEHOLDER__|$VITE_API_URL|g" /usr/share/nginx/html/config.js
 
 echo "Frontend configuration complete"
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,4 @@
+// Runtime configuration - this will be replaced by the docker entrypoint frontend script
+window.__APP_CONFIG__ = {
+  API_BASE_URL: "__VITE_API_URL_PLACEHOLDER__",
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,30 @@
 import axios from 'axios';
 import type { Feed, Episode } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || '__VITE_API_URL_PLACEHOLDER__';
+// Type for runtime configuration
+interface AppConfig {
+  API_BASE_URL: string;
+}
+
+// Extend window interface to include our app config
+declare global {
+  interface Window {
+    __APP_CONFIG__?: AppConfig;
+  }
+}
+
+// Get API URL from runtime config or fall back to environment variable
+const getApiBaseUrl = (): string => {
+  // First try the runtime config (set by Docker entrypoint)
+  if (typeof window !== 'undefined' && window.__APP_CONFIG__) {
+    return window.__APP_CONFIG__.API_BASE_URL;
+  }
+
+  // Fall back to Vite environment variable (for development)
+  return import.meta.env.VITE_API_URL || 'http://localhost:5002';
+};
+
+const API_BASE_URL = getApiBaseUrl();
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
The previous method I implemented didn't work correctly because Vite processes environment variables at build time, not runtime. 

When the Docker image was being built, `VITE_API_URL` wasn't available, so Vite compiled the hardcoded fallback value (http://localhost:5002) directly into the JavaScript bundle. The original approach of trying to replace strings in the built JavaScript files after the fact was flawed because the placeholder `__VITE_API_URL_PLACEHOLDER__` wasn't actually being used in the compiled output.

This PR addresses that issue by using a runtime config file.

I used my forked branch to build both of these containers through the same HitHub workflow this project uses, and tested those containers to verify this does in fact work. The good news is, it does!