### PR TITLE
Fix 'File name too long' error with filename length limiting

### DIFF
--- a/src/app/routes/feed_routes.py
+++ b/src/app/routes/feed_routes.py
@@ -359,6 +359,10 @@ def _cleanup_feed_directories(feed: Feed) -> None:
     ).strip()
     sanitized_feed_title = sanitized_feed_title.rstrip(".")
     sanitized_feed_title = re.sub(r"\s+", "_", sanitized_feed_title)
+    # Limit length to prevent path too long errors
+    max_length = 100  # Conservative limit for directory name
+    if len(sanitized_feed_title) > max_length:
+        sanitized_feed_title = sanitized_feed_title[:max_length].rstrip("_")
 
     srv_feed_dir = get_srv_root() / sanitized_feed_title
     if srv_feed_dir.exists() and srv_feed_dir.is_dir():

--- a/src/podcast_processor/podcast_downloader.py
+++ b/src/podcast_processor/podcast_downloader.py
@@ -109,7 +109,16 @@ class PodcastDownloader:
 
 def sanitize_title(title: str) -> str:
     """Sanitize a title for use in file paths."""
-    return re.sub(r"[^a-zA-Z0-9\s]", "", title)
+    # Remove special characters, keep only alphanumeric and spaces
+    sanitized = re.sub(r"[^a-zA-Z0-9\s]", "", title)
+    # Replace multiple spaces with single space and strip
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    # Limit length to prevent filename too long errors
+    # Leave room for .mp3 extension and path components
+    max_length = 100  # Conservative limit for filename
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length].rstrip()
+    return sanitized
 
 
 def find_audio_link(entry: Any) -> str:

--- a/src/shared/processing_paths.py
+++ b/src/shared/processing_paths.py
@@ -20,6 +20,10 @@ def paths_from_unprocessed_path(
     sanitized_feed_title = sanitized_feed_title.rstrip(".")
     # Replace spaces with underscores for friendlier directory names
     sanitized_feed_title = re.sub(r"\s+", "_", sanitized_feed_title)
+    # Limit length to prevent path too long errors
+    max_length = 100  # Conservative limit for directory name
+    if len(sanitized_feed_title) > max_length:
+        sanitized_feed_title = sanitized_feed_title[:max_length].rstrip("_")
 
     return ProcessingPaths(
         post_processed_audio_path=get_srv_root()
@@ -35,6 +39,12 @@ def get_job_unprocessed_path(post_guid: str, job_id: str, post_title: str) -> Pa
     """
     # Keep same sanitization behavior used for download filenames
     sanitized_title = re.sub(r"[^a-zA-Z0-9\s]", "", post_title).strip()
+    # Replace multiple spaces with single space
+    sanitized_title = re.sub(r"\s+", " ", sanitized_title)
+    # Limit length to prevent filename too long errors
+    max_length = 100  # Conservative limit for filename
+    if len(sanitized_title) > max_length:
+        sanitized_title = sanitized_title[:max_length].rstrip()
     return get_in_root() / "jobs" / post_guid / job_id / f"{sanitized_title}.mp3"
 
 

--- a/src/tests/test_filenames.py
+++ b/src/tests/test_filenames.py
@@ -16,3 +16,19 @@ def test_filenames() -> None:
         / "fix_buzz_bang_a_show_about_stuff"
         / "unprocessed.mp3",
     )
+
+
+def test_long_filenames() -> None:
+    """Test that long filenames are truncated to prevent path too long errors."""
+    # Test with a very long feed title
+    long_title = "A" * 200  # 200 character title
+    work_paths = paths_from_unprocessed_path(
+        "some/path/to/my/unprocessed.mp3", long_title
+    )
+    # Should be truncated to 100 characters
+    expected_title = "A" * 100
+    assert work_paths == ProcessingPaths(
+        post_processed_audio_path=get_srv_root()
+        / expected_title
+        / "unprocessed.mp3",
+    )

--- a/src/tests/test_podcast_downloader.py
+++ b/src/tests/test_podcast_downloader.py
@@ -65,6 +65,23 @@ def test_sanitize_title():
     assert sanitize_title("") == ""
 
 
+def test_sanitize_title_length_limiting():
+    """Test that long titles are truncated to prevent filename too long errors."""
+    # Test with a very long title
+    long_title = "A" * 200  # 200 character title
+    result = sanitize_title(long_title)
+    # Should be truncated to 100 characters
+    assert result == "A" * 100
+    assert len(result) == 100
+
+    # Test with title that has spaces at the end after truncation
+    title_with_spaces = "Test Title " + "A" * 150
+    result = sanitize_title(title_with_spaces)
+    # Should be truncated and trailing spaces removed
+    assert len(result) <= 100
+    assert result == result.rstrip()
+
+
 def test_get_and_make_download_path(downloader):
     path = downloader.get_and_make_download_path("Test Episode!")
 


### PR DESCRIPTION
- Add 100-character length limit to sanitize_title() in podcast_downloader.py
- Update paths_from_unprocessed_path() and get_job_unprocessed_path() in processing_paths.py
- Add length limiting to feed directory cleanup in feed_routes.py

This prevents errno 36 'File name too long' errors when processing podcasts with very long titles.