### PR TITLE
feat: speed up ad expansion and refine boundaries

### DIFF
--- a/src/boundary_refinement_prompt.jinja
+++ b/src/boundary_refinement_prompt.jinja
@@ -1,0 +1,26 @@
+You are refining advertisement boundaries in podcast transcripts.
+
+BOUNDARY RULES:
+- Extend START for: "brought to you by", "let me tell you about", "speaking of"
+- Extend END for: "thanks to", ".com", "use code", "visit"
+- Stop at: "back to", "anyway", "let's continue", topic changes
+
+DETECTED AD: {{ad_start}}s - {{ad_end}}s (confidence: {{ad_confidence}})
+
+CONTEXT:
+{% for seg in context_segments -%}
+[{{seg.start_time}}s] {{seg.text}}
+{% endfor %}
+
+Return JSON:
+{
+  "refined_start": {{ad_start}},
+  "refined_end": {{ad_end}},
+  "start_reason": "explanation",
+  "end_reason": "explanation"
+}
+
+Constraints:
+- Max start extension: {{max_start_extension}}s backward
+- Max end extension: {{max_end_extension}}s forward
+- Ensure refined_start < refined_end

--- a/src/podcast_processor/boundary_refiner.py
+++ b/src/podcast_processor/boundary_refiner.py
@@ -1,0 +1,154 @@
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import litellm
+from jinja2 import Template
+
+from shared.config import Config
+
+
+@dataclass
+class BoundaryRefinement:
+    refined_start: float
+    refined_end: float
+    start_reason: str
+    end_reason: str
+
+
+class BoundaryRefiner:
+    def __init__(self, config: Config, logger: Optional[logging.Logger] = None):
+        self.config = config
+        self.logger = logger or logging.getLogger(__name__)
+        self.template = self._load_template()
+
+    def _load_template(self) -> Template:
+        path = (
+            Path(__file__).resolve().parent.parent  # project src root
+            / "boundary_refinement_prompt.jinja"
+        )
+        if path.exists():
+            return Template(path.read_text())
+        # Minimal fallback
+        return Template(
+            """Refine ad boundaries.
+Ad: {{ad_start}}s-{{ad_end}}s
+{% for seg in context_segments %}[{{seg.start_time}}] {{seg.text}}
+{% endfor %}
+Return JSON: {"refined_start": {{ad_start}}, "refined_end": {{ad_end}}, "start_reason": "", "end_reason": ""}"""
+        )
+
+    def refine(
+        self,
+        ad_start: float,
+        ad_end: float,
+        confidence: float,
+        all_segments: List[Dict[str, Any]],
+    ) -> BoundaryRefinement:
+        """Refine ad boundaries using LLM analysis"""
+        context = self._get_context(ad_start, ad_end, all_segments)
+
+        try:
+            # Try LLM refinement
+            prompt = self.template.render(
+                ad_start=ad_start,
+                ad_end=ad_end,
+                ad_confidence=confidence,
+                context_segments=context,
+                max_start_extension=getattr(
+                    self.config, "max_start_extension_seconds", 30.0
+                ),
+                max_end_extension=getattr(
+                    self.config, "max_end_extension_seconds", 15.0
+                ),
+            )
+
+            response = litellm.completion(
+                model=self.config.llm_model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.1,
+                max_tokens=500,
+                timeout=self.config.openai_timeout,
+            )
+
+            content = response.choices[0].message.content
+            # Parse JSON (strip markdown fences)
+            cleaned = re.sub(r"```json|```", "", content.strip())
+            match = re.search(r"\{[^}]+\}", cleaned)
+            if match:
+                data = json.loads(match.group(0))
+                return self._validate(
+                    ad_start,
+                    ad_end,
+                    BoundaryRefinement(
+                        refined_start=float(data["refined_start"]),
+                        refined_end=float(data["refined_end"]),
+                        start_reason=data.get("start_reason", ""),
+                        end_reason=data.get("end_reason", ""),
+                    ),
+                )
+        except Exception as e:
+            self.logger.warning(f"LLM refinement failed: {e}, using heuristic")
+
+        # Fallback: heuristic refinement
+        return self._heuristic_refine(ad_start, ad_end, context)
+
+    def _get_context(
+        self, ad_start: float, ad_end: float, all_segments: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Get ±8 segments around ad"""
+        ad_segs = [s for s in all_segments if ad_start <= s["start_time"] <= ad_end]
+        if not ad_segs:
+            return []
+
+        first_idx = all_segments.index(ad_segs[0])
+        last_idx = all_segments.index(ad_segs[-1])
+
+        start_idx = max(0, first_idx - 8)
+        end_idx = min(len(all_segments), last_idx + 9)
+
+        return all_segments[start_idx:end_idx]
+
+    def _heuristic_refine(
+        self, ad_start: float, ad_end: float, context: List[Dict[str, Any]]
+    ) -> BoundaryRefinement:
+        """Simple pattern-based refinement"""
+        intro_patterns = ["brought to you", "sponsor", "let me tell you"]
+        outro_patterns = [".com", "thanks to", "use code", "visit"]
+
+        refined_start = ad_start
+        refined_end = ad_end
+
+        # Check before ad for intros
+        for seg in context:
+            if seg["start_time"] < ad_start:
+                if any(p in seg["text"].lower() for p in intro_patterns):
+                    refined_start = seg["start_time"]
+
+        # Check after ad for outros
+        for seg in context:
+            if seg["start_time"] > ad_end:
+                if any(p in seg["text"].lower() for p in outro_patterns):
+                    refined_end = seg.get("end_time", seg["start_time"] + 5.0)
+
+        return BoundaryRefinement(refined_start, refined_end, "heuristic", "heuristic")
+
+    def _validate(
+        self, orig_start: float, orig_end: float, refinement: BoundaryRefinement
+    ) -> BoundaryRefinement:
+        """Constrain refinement to reasonable bounds"""
+        max_start_ext = getattr(self.config, "max_start_extension_seconds", 30.0)
+        max_end_ext = getattr(self.config, "max_end_extension_seconds", 15.0)
+
+        if refinement.refined_start < orig_start - max_start_ext:
+            refinement.refined_start = orig_start - max_start_ext
+        if refinement.refined_end > orig_end + max_end_ext:
+            refinement.refined_end = orig_end + max_end_ext
+        if refinement.refined_start >= refinement.refined_end:
+            refinement.refined_start = orig_start
+            refinement.refined_end = orig_end
+
+        return refinement

--- a/src/podcast_processor/cue_detector.py
+++ b/src/podcast_processor/cue_detector.py
@@ -1,0 +1,22 @@
+import re
+from typing import Pattern
+
+
+class CueDetector:
+    def __init__(self) -> None:
+        self.url_pattern: Pattern[str] = re.compile(
+            r"\b([a-z0-9\-\.]+\.(?:com|net|org|io))\b", re.I
+        )
+        self.promo_pattern: Pattern[str] = re.compile(
+            r"\b(code|promo|save|discount)\s+\w+\b", re.I
+        )
+        self.phone_pattern: Pattern[str] = re.compile(
+            r"\b(?:\+?1[ -]?)?\d{3}[ -]?\d{3}[ -]?\d{4}\b"
+        )
+
+    def has_cue(self, text: str) -> bool:
+        return bool(
+            self.url_pattern.search(text)
+            or self.promo_pattern.search(text)
+            or self.phone_pattern.search(text)
+        )


### PR DESCRIPTION
**Optimize ad classification with bulk operations and boundary refinement**

**Problem**
1. Neighbor expansion issues ~900 SQL queries per episode, driving ~60s processing times.
2. Ads are labeled in 10-second chunks, so their boundaries often clip or miss sponsor reads, producing 30–40% false positives around segment edges.

**Solution**
Add two enhancements that run after the primary LLM pass:
1. Bulk neighbor expansion fetches all candidate segments, deduplicates existing identifications, detects promo cues (URLs, codes, phone numbers), and inserts new ads in three queries instead of hundreds.
2. Boundary refinement groups adjacent ads into blocks and (optionally) sends each block to a purpose-built LLM prompt to tighten the start/end times. A heuristic fallback keeps things working even when the LLM is unavailable. The feature remains opt-in via `BOUNDARY_REFINEMENT_ENABLED`.

**Technical changes**
- Added `CueDetector` for promo-heuristic neighbor filtering and wired it into `AdClassifier.expand_neighbors_bulk`.
- Added `BoundaryRefiner`, its prompt template, and the `_refine_boundaries` pipeline to re-evaluate grouped ad blocks, delete stale identifications, and recreate them with refined spans.
- Ensured the boundary prompt loads via a path relative to `boundary_refiner.py`, so deployments do not depend on the current working directory.
- Updated `AdClassifier` to call the new bulk expander and optional refiner, plus added helper methods for block grouping, mapper-safe bulk inserts, and constraint checks.

**Testing**
- `pipenv install --dev --python 3.11`
- `bash scripts/ci.sh` (black, isort, mypy, pylint, pytest all passed)
