### PR TITLE
patch: Enhance environment configuration and validation for API keys in .env

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,6 +15,17 @@ GROQ_API_KEY=gsk_abcdefghjiklmnopqrstuvwxyz
 # --- LLM (OpenAI-compatible or proxy) ---
 # ========================================
 
+# Base URL is IGNORED when LLM_MODEL is provider-prefixed like the examples below:
+# groq/openai/gpt-oss-120b  (Groq API)
+# anthropic/claude-3.5-sonnet (Anthropic API)
+# gemini/gemini-3-flash-preview (Google API)
+# gemini/gemini-2.0-flash (Google API)
+
+# Base URL is USED for:
+# Unprefixed models like gpt-4o
+# Self-hosted OpenAI-compatible endpoints
+# LiteLLM proxy servers or local LLMs
+
 LLM_API_KEY=sk-your-openai-or-compatible-key
 LLM_MODEL=gpt-4o
 

--- a/.env.local:Zone.Identifier
+++ b/.env.local:Zone.Identifier
@@ -1,1 +1,0 @@
-export REQUIRE_AUTH=false

--- a/docs/how_to_run_beginners.md
+++ b/docs/how_to_run_beginners.md
@@ -6,7 +6,7 @@ This guide will walk you through setting up Podly from scratch using Docker. Pod
 
 Want an expert to guide you through the setup? Download an AI powered IDE like cursor https://www.cursor.com/ or windsurf https://windsurf.com/
 
-Most IDEs have a free tier you can use to get started. Alternatively, you can use your own [LLM API key in Cursor](https://docs.cursor.com/settings/api-keys) (you'll need a key for Podly anyways).
+Most IDEs have a free tier you can use to get started. Alternatively, you can use your own [LLM API key in Cursor](https://docs.cursor.com/settings/api-keys).
 
 Open the AI chat in the IDE. Enable 'Agent' mode if available, which will allow the IDE to help you run commands, view the output, and debug or take corrective steps if necessary.
 
@@ -86,7 +86,7 @@ docker compose version
 
 You should see version information for both commands.
 
-### 2. Get an OpenAI API Key
+### 2. Get an OpenAI API Key (if using OpenAI)
 
 1. Go to [OpenAI's API platform](https://platform.openai.com/)
 2. Sign up for an account or log in if you already have one
@@ -103,7 +103,7 @@ You should see version information for both commands.
 ### Download the Project
 
 ```bash
-git clone https://github.com/normand1/podly_pure_podcasts.git
+git clone https://github.com/podly-pure-podcasts/podly_pure_podcasts.git
 cd podly_pure_podcasts
 ```
 
@@ -120,9 +120,9 @@ chmod +x run_podly_docker.sh
 
 ### Optional: Enable Authentication
 
-The Docker image reads environment variables from `.env` files or your shell. To require login:
+The Docker image reads environment variables from `.env.local` files or your shell. To require login:
 
-1. Export the variables before running Podly, or add them to `config/.env`:
+1. Export the variables before running Podly, or add them to `config/.env.local`:
 
 ```bash
 export REQUIRE_AUTH=true

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -34,6 +34,7 @@ from app.processor import (
 from app.routes import register_routes
 from app.runtime_config import config, is_test
 from app.writer.client import writer_client
+from shared import defaults as DEFAULTS
 from shared.processing_paths import get_in_root, get_srv_root
 
 setup_logger("global_logger", "src/instance/logs/app.log")
@@ -235,13 +236,17 @@ def _validate_env_key_conflicts() -> None:
     """Validate that environment API key variables are not conflicting.
 
     Rules:
-    - If both LLM_API_KEY and GROQ_API_KEY are set and differ -> error
+    - If Groq is being used as the LLM and both LLM_API_KEY and GROQ_API_KEY are
+      set but differ -> error
     """
     llm_key = os.environ.get("LLM_API_KEY")
     groq_key = os.environ.get("GROQ_API_KEY")
+    llm_model = os.environ.get("LLM_MODEL") or DEFAULTS.LLM_DEFAULT_MODEL
+    llm_model_norm = llm_model.strip().lower() if isinstance(llm_model, str) else ""
+    groq_llm_selected = llm_model_norm.startswith("groq/")
 
     conflicts: list[str] = []
-    if llm_key and groq_key and llm_key != groq_key:
+    if groq_llm_selected and llm_key and groq_key and llm_key != groq_key:
         conflicts.append(
             "LLM_API_KEY and GROQ_API_KEY are both set but have different values"
         )

--- a/src/tests/test_config_error_handling.py
+++ b/src/tests/test_config_error_handling.py
@@ -120,10 +120,19 @@ class TestEnvKeyValidation:
     def test_llm_and_groq_conflict_raises(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("LLM_API_KEY", "llm-value")
         monkeypatch.setenv("GROQ_API_KEY", "groq-value")
+        monkeypatch.setenv("LLM_MODEL", "groq/openai/gpt-oss-120b")
         monkeypatch.delenv("WHISPER_REMOTE_API_KEY", raising=False)
 
         with pytest.raises(SystemExit):
             app_module._validate_env_key_conflicts()
+
+    def test_non_groq_llm_allows_different_groq_key(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("LLM_API_KEY", "llm-value")
+        monkeypatch.setenv("GROQ_API_KEY", "groq-value")
+        monkeypatch.setenv("LLM_MODEL", "google/gemini-1.5-pro")
+        monkeypatch.delenv("WHISPER_REMOTE_API_KEY", raising=False)
+
+        app_module._validate_env_key_conflicts()
 
     def test_whisper_remote_allows_different_key(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("LLM_API_KEY", "llm-value")


### PR DESCRIPTION
## Summary
- Improve validation logic for API keys to ensure proper scoping based on the selected LLM model. Previously you could not use LLM_API_KEY if you were using GROQ whisper and had to use OPENAI_API_KEY as a workaround.
- Update `.env.local.example` with additional examples to aid in configuration.
- Update some outdated info in the beginner's guide

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs
- [ ] Other

## Testing
- [x] `scripts/ci.sh`
- [ ] Not run (explain below)

## Docs
- [x] Updated (details below)

## Related issues
- https://github.com/podly-pure-podcasts/podly_pure_podcasts/issues/171
- User was having issues because they didn't realize they should a provider-prefixed model
- User was also having issues because they were trying to use LLM_API_KEY while using groq for whisper but NOT for LLM

## Notes
- 

## Checklist
- [x] Target branch is `Preview`
- [x] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning

