### PR TITLE
feat: add advertisement removal summary and processing stats to the UI

### DIFF
--- a/frontend/src/components/ProcessingStatsButton.tsx
+++ b/frontend/src/components/ProcessingStatsButton.tsx
@@ -34,6 +34,18 @@ export default function ProcessingStatsButton({
     return `${minutes}m ${secs}s`;
   };
 
+  const formatTimelineLabel = (seconds: number) => {
+    const totalSeconds = Math.max(0, Math.round(seconds));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const secs = totalSeconds % 60;
+
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    }
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  };
+
   const formatTimestamp = (timestamp: string | null) => {
     if (!timestamp) return 'N/A';
     return new Date(timestamp).toLocaleString();
@@ -142,7 +154,7 @@ export default function ProcessingStatsButton({
                       {/* Key Metrics */}
                       <div>
                         <h3 className="font-semibold text-gray-900 mb-4 text-left">Key Metrics</h3>
-                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                           <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-4 text-center">
                             <div className="text-2xl font-bold text-blue-600">
                               {stats.processing_stats?.total_segments || 0}
@@ -165,6 +177,120 @@ export default function ProcessingStatsButton({
                           </div>
                         </div>
                       </div>
+
+                      {/* Advertisement Removal Summary */}
+                      {(() => {
+                        const durationSeconds = stats.post?.duration
+                          ?? (stats.transcript_segments?.length
+                            ? Math.max(...stats.transcript_segments.map((segment) => segment.end_time))
+                            : 0);
+                        const fallbackAdBlocks = (() => {
+                          const adSegments = (stats.transcript_segments || [])
+                            .filter((segment) => segment.primary_label === 'ad')
+                            .map((segment) => ({ start: segment.start_time, end: segment.end_time }))
+                            .sort((a, b) => a.start - b.start);
+
+                          if (!adSegments.length) return [];
+
+                          const merged: Array<{ start: number; end: number }> = [];
+                          let current = { ...adSegments[0] };
+                          const gapSeconds = 1;
+                          for (const segment of adSegments.slice(1)) {
+                            if (segment.start <= current.end + gapSeconds) {
+                              current.end = Math.max(current.end, segment.end);
+                            } else {
+                              merged.push(current);
+                              current = { ...segment };
+                            }
+                          }
+                          merged.push(current);
+                          return merged;
+                        })();
+
+                        const apiAdBlocks = (stats.processing_stats?.ad_blocks || []).map((block) => ({
+                          start: block.start_time,
+                          end: block.end_time,
+                        }));
+                        const adBlocks = apiAdBlocks.length ? apiAdBlocks : fallbackAdBlocks;
+                        const adTimeSeconds = stats.processing_stats?.estimated_ad_time_seconds
+                          ?? adBlocks.reduce((sum, block) => sum + Math.max(0, block.end - block.start), 0);
+                        const adPercent = durationSeconds > 0
+                          ? (adTimeSeconds / durationSeconds) * 100
+                          : 0;
+                        const cleanSeconds = Math.max(0, durationSeconds - adTimeSeconds);
+                        const timelineTicks = [0, 0.25, 0.5, 0.75, 1];
+
+                        return (
+                          <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
+                            <h3 className="font-semibold text-gray-900 mb-4 text-left">Advertisement Removal Summary</h3>
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
+                              <div>
+                                <div className="text-2xl font-bold text-blue-600">{adBlocks.length}</div>
+                                <div className="text-sm text-gray-600">Ad Blocks</div>
+                              </div>
+                              <div>
+                                <div className="text-2xl font-bold text-blue-600">{formatDuration(adTimeSeconds)}</div>
+                                <div className="text-sm text-gray-600">Time Removed</div>
+                              </div>
+                              <div>
+                                <div className="text-2xl font-bold text-rose-600">{adPercent.toFixed(1)}%</div>
+                                <div className="text-sm text-gray-600">Episode Reduced</div>
+                              </div>
+                            </div>
+
+                            <div className="mt-5 space-y-3">
+                              <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-gray-600">
+                                <div className="flex items-center gap-2">
+                                  <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white text-gray-500 border border-gray-200">
+                                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                  </span>
+                                  Episode Timeline
+                                </div>
+                                <div className="text-gray-600">
+                                  {formatDuration(cleanSeconds)} clean
+                                  <span className="text-rose-600 ml-2">
+                                    {formatDuration(adTimeSeconds)} removed ({adPercent.toFixed(1)}%)
+                                  </span>
+                                </div>
+                              </div>
+
+                              <div className="relative h-3 w-full rounded-full bg-gray-200 overflow-hidden">
+                                <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 via-blue-400/15 to-blue-500/20" />
+                                {durationSeconds > 0 && adBlocks.map((block, index) => {
+                                  const left = Math.max(0, (block.start / durationSeconds) * 100);
+                                  const width = Math.max(0.5, ((block.end - block.start) / durationSeconds) * 100);
+                                  return (
+                                    <div
+                                      key={`${block.start}-${block.end}-${index}`}
+                                      className="absolute top-0 h-full rounded-full bg-rose-500/70"
+                                      style={{ left: `${left}%`, width: `${width}%` }}
+                                    />
+                                  );
+                                })}
+                              </div>
+
+                              <div className="flex justify-between text-xs text-gray-500">
+                                {timelineTicks.map((tick) => (
+                                  <span key={tick}>{formatTimelineLabel(durationSeconds * tick)}</span>
+                                ))}
+                              </div>
+
+                              <div className="flex items-center gap-4 text-xs text-gray-500">
+                                <span className="flex items-center gap-2">
+                                  <span className="h-2 w-2 rounded-full bg-blue-500" />
+                                  Content
+                                </span>
+                                <span className="flex items-center gap-2">
+                                  <span className="h-2 w-2 rounded-full bg-rose-500" />
+                                  Ads removed
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })()}
 
                       {/* Model Performance */}
                       <div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -268,6 +268,10 @@ export const feedsApi = {
       ad_segments_count: number;
       ad_percentage: number;
       estimated_ad_time_seconds: number;
+      ad_blocks?: Array<{
+        start_time: number;
+        end_time: number;
+      }>;
       model_call_statuses: Record<string, number>;
       model_types: Record<string, number>;
     };
@@ -369,6 +373,10 @@ export const feedsApi = {
       ad_segments_count: number;
       ad_percentage: number;
       estimated_ad_time_seconds: number;
+      ad_blocks?: Array<{
+        start_time: number;
+        end_time: number;
+      }>;
       model_call_statuses: Record<string, number>;
       model_types: Record<string, number>;
     };

--- a/src/app/routes/post_stats_utils.py
+++ b/src/app/routes/post_stats_utils.py
@@ -47,6 +47,27 @@ def parse_refined_windows(raw_refined: Any) -> List[Tuple[float, float]]:
     return refined_windows
 
 
+def merge_time_windows(
+    windows: List[Tuple[float, float]], gap_seconds: float = 1.0
+) -> List[Tuple[float, float]]:
+    if not windows:
+        return []
+
+    windows_sorted = sorted(windows, key=lambda w: w[0])
+    merged: List[Tuple[float, float]] = []
+    current_start, current_end = windows_sorted[0]
+
+    for start, end in windows_sorted[1:]:
+        if start <= current_end + gap_seconds:
+            current_end = max(current_end, end)
+        else:
+            merged.append((current_start, current_end))
+            current_start, current_end = start, end
+
+    merged.append((current_start, current_end))
+    return merged
+
+
 def is_mixed_segment(
     *, seg_start: float, seg_end: float, refined_windows: List[Tuple[float, float]]
 ) -> bool:


### PR DESCRIPTION
## Type of change

- [x] New feature


## Testing

- [x] `scripts/ci.sh`

- [ ] Not run (explain below)


## Docs

- [ ] Not needed

- [ ] Updated (details below)


## Notes

- Add advertisement removal summary and processing statistics to the UI.
- Update the grid behavior on the Key Metrics so they fill the width of the modal instead of leaving whitespace 

Desktop 
<img width="1139" height="798" alt="Screenshot 2026-01-28 at 12 24 54 AM" src="https://github.com/user-attachments/assets/caa5a0a5-7fb3-4cae-a6c3-8028679246ce" />

Mobile 
![image](https://github.com/user-attachments/assets/8f23b3fb-d54e-4fdb-9577-703e597010eb)

## Checklist

- [x] Target branch is `Preview`

- [ ] Docs updated if needed

- [x] Tests run or explicitly skipped with reasoning

- [x] If merging to main, at least one commit in this PR follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) Please refer to https://www.conventionalcommits.org/en/v1.0.0/#summary for more details.

