### PR TITLE
feat: Add feed detail route and handle feed selection in HomePage component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -276,6 +276,7 @@ function AppShell() {
       <main className="flex-1 px-2 sm:px-4 lg:px-6 py-4 overflow-auto">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/feeds/:feedId" element={<HomePage />} />
           {showBillingLink && <Route path="/billing" element={<BillingPage />} />}
           {showJobsLink && <Route path="/jobs" element={<JobsPage />} />}
           {showConfigLink && <Route path="/config" element={<ConfigPage />} />}


### PR DESCRIPTION
## Summary
- Introduce a routing for feed details and implement feed selection handling in the HomePage component. This makes it so you can use the back button to go back from feed to feed as you navigate. This especially helpful if viewing the site on mobile where the selected feed takes up the entire screen.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Testing
- [x] `scripts/ci.sh`
- [ ] Not run (explain below)

## Docs
- [x] Not needed
- [ ] Updated (details below)

## Related issues
- 

## Notes
- 

## Checklist
- [x] Target branch is `Preview`
- [x] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning
- [x] If merging to main, at least one commit in this PR follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) Please refer to https://www.conventionalcommits.org/en/v1.0.0/#summary for more details.

