### PR TITLE
fix: Implement auto-whitelist check for first member in feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .worktrees/*
 
+.mypy_cache/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/src/app/routes/feed_utils.py
+++ b/src/app/routes/feed_utils.py
@@ -46,6 +46,12 @@ def whitelist_latest_for_first_member(
     feed: Feed, requested_by_user_id: int | None
 ) -> None:
     """When a feed goes from 0→1 members, whitelist and process the latest post."""
+    # Respect global/per-feed whitelist settings; skip if auto-whitelist is disabled.
+    from app.feeds import _should_auto_whitelist_new_posts
+
+    if not _should_auto_whitelist_new_posts(feed):
+        return
+
     try:
         result = writer_client.action(
             "whitelist_latest_post_for_feed", {"feed_id": feed.id}, wait=True

--- a/src/tests/test_feed_utils.py
+++ b/src/tests/test_feed_utils.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from app.routes.feed_utils import whitelist_latest_for_first_member
+
+
+def test_whitelist_latest_for_first_member_skips_when_auto_whitelist_disabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "app.feeds._should_auto_whitelist_new_posts", lambda feed: False
+    )
+    mock_writer = mock.MagicMock()
+    monkeypatch.setattr("app.routes.feed_utils.writer_client", mock_writer)
+
+    whitelist_latest_for_first_member(SimpleNamespace(id=1), 7)
+
+    mock_writer.action.assert_not_called()
+
+
+def test_whitelist_latest_for_first_member_enqueues_when_enabled(monkeypatch):
+    monkeypatch.setattr("app.feeds._should_auto_whitelist_new_posts", lambda feed: True)
+    mock_writer = mock.MagicMock()
+    mock_writer.action.return_value = SimpleNamespace(
+        success=True, data={"updated": True, "post_guid": "abc-123"}
+    )
+    monkeypatch.setattr("app.routes.feed_utils.writer_client", mock_writer)
+    mock_jobs = mock.MagicMock()
+    monkeypatch.setattr("app.routes.feed_utils.get_jobs_manager", lambda: mock_jobs)
+
+    whitelist_latest_for_first_member(SimpleNamespace(id=5), 11)
+
+    mock_writer.action.assert_called_once_with(
+        "whitelist_latest_post_for_feed", {"feed_id": 5}, wait=True
+    )
+    mock_jobs.start_post_processing.assert_called_once_with(
+        "abc-123",
+        priority="interactive",
+        requested_by_user_id=11,
+        billing_user_id=11,
+    )


### PR DESCRIPTION
## Summary
- Add an auto-whitelist check that respects global and per-feed settings when a feed transitions from 0 to 1 members, so when user sets Auto-whitelist new episodes to false globally it doesn't  still whitelist the newest episode.

## Type of change
- [x] Bug fix

## Testing
- [x] `scripts/ci.sh`

## Docs
- [ ] Not needed

## Checklist
- [x] Target branch is `Preview`
- [ ] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning
- [x] If merging to main, at least one commit in this PR follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) Please refer to https://www.conventionalcommits.org/en/v1.0.0/#summary for more details.

