### PR TITLE
ci: migrate ARM64 Docker build to native GitHub ARM runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -314,7 +314,7 @@ jobs:
   build-arm64:
     needs: changes
     if: ${{ needs.changes.outputs.skip == 'false' && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         variant:
@@ -378,10 +378,6 @@ jobs:
           docker system prune -af
           echo "Available disk space after cleanup:"
           df -h
-
-      - name: Set up QEMU
-        if: ${{ steps.select.outputs.enabled == 'true' }}
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: ${{ steps.select.outputs.enabled == 'true' }}


### PR DESCRIPTION
## Summary
- Switch `build-arm64` job from `ubuntu-latest` + QEMU emulation to GitHub's free native ARM runner (`ubuntu-24.04-arm`)
- Remove the now-unnecessary QEMU setup step
- Tested on fork: native ARM builds are ~4x faster (latest: 11m11s → 2m36s, lite: 8m28s → 1m58s)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [x] Other

## Testing
- [x] `scripts/ci.sh`
- [x] Tested via fork PR — merged to fork main, confirmed `build-arm64` jobs complete successfully on `ubuntu-24.04-arm`

### Build time comparison (fork)

| Job | QEMU (old) | Native ARM (new) | Speedup |
|---|---|---|---|
| build-arm64 (latest) | 11m11s | 2m36s | ~4.3x |
| build-arm64 (lite) | 8m28s | 1m58s | ~4.3x |

## Docs
- [x] Not needed

## Related issues
- 

## Notes
- Only the `build-arm64` job is affected. All other workflows are architecture-agnostic.
- No QEMU needed since the runner is natively ARM.

## Checklist
- [x] Target branch is `Preview`
- [x] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning
- [x] If merging to main, at least one commit in this PR follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) Please refer to https://www.conventionalcommits.org/en/v1.0.0/#summary for more details.