### PR TITLE
feat: Add Dark Mode and fix front end issues

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,44 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Podly</title>
+    <script>
+      (() => {
+        const storageKey = 'podly-theme';
+
+        try {
+          const storedPreference = window.localStorage.getItem(storageKey);
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const resolvedTheme =
+            storedPreference === 'light' || storedPreference === 'dark'
+              ? storedPreference
+              : prefersDark
+                ? 'dark'
+                : 'light';
+          const preference =
+            storedPreference === 'system' || storedPreference === 'light' || storedPreference === 'dark'
+              ? storedPreference
+              : 'system';
+
+          if (resolvedTheme === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+
+          document.documentElement.style.colorScheme = resolvedTheme;
+          document.documentElement.dataset.themePreference = preference;
+        } catch (_error) {
+          const fallbackTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+
+          if (fallbackTheme === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+
+          document.documentElement.style.colorScheme = fallbackTheme;
+          document.documentElement.dataset.themePreference = 'system';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -88,3 +88,15 @@ html, body {
 ::-webkit-scrollbar-thumb:hover {
   background: #a8a8a8;
 }
+
+html.dark ::-webkit-scrollbar-track {
+  background: #0f172a;
+}
+
+html.dark ::-webkit-scrollbar-thumb {
+  background: #475569;
+}
+
+html.dark ::-webkit-scrollbar-thumb:hover {
+  background: #64748b;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import AudioPlayer from './components/AudioPlayer';
 import { billingApi } from './services/api';
 import { DiagnosticsProvider, useDiagnostics } from './contexts/DiagnosticsContext';
 import DiagnosticsModal from './components/DiagnosticsModal';
+import ThemeToggle from './components/ThemeToggle';
+import { ThemeProvider, useTheme } from './contexts/ThemeContext';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -32,6 +34,7 @@ const queryClient = new QueryClient({
 function AppShell() {
   const { status, requireAuth, isAuthenticated, user, logout, landingPageEnabled } = useAuth();
   const { open: openDiagnostics } = useDiagnostics();
+  const { isDark } = useTheme();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
@@ -139,6 +142,7 @@ function AppShell() {
               >
                 Report issue
               </button>
+              <ThemeToggle />
               {requireAuth && user && (
                 <div className="flex items-center gap-3 text-sm text-gray-600 flex-shrink-0">
                   {billingSummary && !isAdmin && (
@@ -186,6 +190,8 @@ function AppShell() {
                   </Link>
                 </>
               )}
+
+              <ThemeToggle />
 
               {/* Hamburger Button */}
               <div className="relative" ref={mobileMenuRef}>
@@ -286,7 +292,23 @@ function AppShell() {
 
       <AudioPlayer />
       <DiagnosticsModal />
-      <Toaster position="top-center" toastOptions={{ duration: 3000 }} />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          duration: 3000,
+          style: isDark
+            ? {
+                background: '#0f172a',
+                color: '#e2e8f0',
+                border: '1px solid #334155',
+              }
+            : {
+                background: '#ffffff',
+                color: '#111827',
+                border: '1px solid #e5e7eb',
+              },
+        }}
+      />
     </div>
   );
 }
@@ -294,15 +316,17 @@ function AppShell() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <AudioPlayerProvider>
-          <DiagnosticsProvider>
-            <Router>
-              <AppShell />
-            </Router>
-          </DiagnosticsProvider>
-        </AudioPlayerProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <AudioPlayerProvider>
+            <DiagnosticsProvider>
+              <Router>
+                <AppShell />
+              </Router>
+            </DiagnosticsProvider>
+          </AudioPlayerProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/ChapterProcessingStats.tsx
+++ b/frontend/src/components/ChapterProcessingStats.tsx
@@ -142,27 +142,27 @@ export default function ChapterProcessingStats({
                       <div>
                         <h3 className="font-semibold text-gray-900 mb-4 text-left">Key Metrics</h3>
                         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                          <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-purple-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-purple-50 to-purple-100 p-4 text-center dark:border-purple-800/70 dark:from-purple-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-purple-600 dark:text-purple-200">
                               {stats.chapters?.total_chapters || 0}
                             </div>
-                            <div className="text-sm text-purple-800">Total Chapters</div>
+                            <div className="text-sm text-purple-800 dark:text-purple-100">Total Chapters</div>
                           </div>
 
-                          <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-green-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-green-50 to-green-100 p-4 text-center dark:border-green-800/70 dark:from-green-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-green-600 dark:text-green-200">
                               {stats.chapters?.chapters_kept || 0}
                             </div>
-                            <div className="text-sm text-green-800">
+                            <div className="text-sm text-green-800 dark:text-green-100">
                               {isChapterInsert ? 'Chapters Inserted' : 'Chapters Kept'}
                             </div>
                           </div>
 
-                          <div className="bg-gradient-to-br from-red-50 to-red-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-red-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-red-50 to-red-100 p-4 text-center dark:border-red-800/70 dark:from-red-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-red-600 dark:text-red-200">
                               {stats.chapters?.chapters_removed || 0}
                             </div>
-                            <div className="text-sm text-red-800">
+                            <div className="text-sm text-red-800 dark:text-red-100">
                               {isChapterInsert ? 'Chapters Removed (N/A)' : 'Chapters Removed'}
                             </div>
                           </div>

--- a/frontend/src/components/DownloadButton.tsx
+++ b/frontend/src/components/DownloadButton.tsx
@@ -101,10 +101,10 @@ export default function DownloadButton({
   if (isCompleted && downloadUrl) {
     return (
       <div className={`${className}`}>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-start gap-2">
           <button
             onClick={handleDownloadClick}
-            className="px-3 py-1 text-xs rounded font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700"
+            className="shrink-0 px-3 py-1 text-xs rounded font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700"
             title="Download processed episode"
           >
             Download

--- a/frontend/src/components/DownloadButton.tsx
+++ b/frontend/src/components/DownloadButton.tsx
@@ -101,7 +101,7 @@ export default function DownloadButton({
   if (isCompleted && downloadUrl) {
     return (
       <div className={`${className}`}>
-        <div className="flex flex-wrap items-start gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <button
             onClick={handleDownloadClick}
             className="shrink-0 px-3 py-1 text-xs rounded font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700"

--- a/frontend/src/components/FeedDetail.tsx
+++ b/frontend/src/components/FeedDetail.tsx
@@ -617,7 +617,7 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
   };
 
   return (
-    <div className="h-full flex flex-col bg-white relative">
+    <div className="h-full flex flex-col bg-white relative dark:bg-slate-950/40">
       {/* Mobile Header */}
       <div className="flex items-center justify-between p-4 border-b lg:hidden">
         <h2 className="text-lg font-semibold text-gray-900">Podcast Details</h2>
@@ -634,7 +634,7 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
       </div>
 
       {/* Sticky Header - appears when scrolling */}
-      <div className={`absolute top-16 lg:top-0 left-0 right-0 z-10 bg-white border-b transition-all duration-300 ${
+      <div className={`absolute top-16 lg:top-0 left-0 right-0 z-10 bg-white border-b dark:bg-slate-950/95 dark:border-slate-700 transition-all duration-300 ${
         showStickyHeader ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-full pointer-events-none'
       }`}>
         <div className="p-4">

--- a/frontend/src/components/FeedDetail.tsx
+++ b/frontend/src/components/FeedDetail.tsx
@@ -780,12 +780,19 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                       : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                   }`}
                 >
-                  <img
+                  <svg
                     className={`w-4 h-4 ${refreshFeedMutation.isPending ? 'animate-spin' : ''}`}
-                    src="/reload-icon.svg"
-                    alt="Refresh feed"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     aria-hidden="true"
-                  />
+                  >
+                    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                    <path d="M21 3v6h-6" />
+                  </svg>
                   <span>Refresh Feed</span>
                 </button>
               )}

--- a/frontend/src/components/FeedDetail.tsx
+++ b/frontend/src/components/FeedDetail.tsx
@@ -729,13 +729,13 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
             </div>
 
             {/* RSS Button and Menu */}
-            <div className="flex items-center gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
               {/* Podly RSS Subscribe Button */}
               {showPodlyRssButton && (
                 <button
                   onClick={handleCopyRssToClipboard}
                   title="Copy Podly RSS feed URL"
-                  className={`flex items-center gap-3 px-5 py-2 bg-black hover:bg-gray-900 text-white rounded-lg font-medium transition-colors ${
+                  className={`flex w-full items-center justify-center gap-3 rounded-lg bg-black px-4 py-3 text-center font-medium text-white transition-colors hover:bg-gray-900 sm:w-auto sm:justify-start sm:px-5 sm:py-2 ${
                     !canSubscribe ? 'opacity-60 cursor-not-allowed' : ''
                   }`}
                   disabled={!canSubscribe}
@@ -743,7 +743,7 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                   <img
                     src="/rss-round-color-icon.svg"
                     alt="Podly RSS"
-                    className="w-6 h-6"
+                    className="h-6 w-6 shrink-0"
                     aria-hidden="true"
                   />
                   <span className="text-white">
@@ -752,79 +752,80 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                 </button>
               )}
 
-              {requireAuth && isAdmin && !isMember && (
-                <button
-                  onClick={() => joinFeedMutation.mutate()}
-                  disabled={joinFeedMutation.isPending}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors ${
-                    joinFeedMutation.isPending
-                      ? 'bg-blue-100 text-blue-300 cursor-not-allowed'
-                      : 'bg-blue-600 text-white hover:bg-blue-700'
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                  </svg>
-                  Join feed
-                </button>
-              )}
-
-              {canModifyEpisodes && (
-                <button
-                  onClick={() => refreshFeedMutation.mutate()}
-                  disabled={refreshFeedMutation.isPending}
-                  title="Refresh feed from source"
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors ${
-                    refreshFeedMutation.isPending
-                      ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }`}
-                >
-                  <svg
-                    className={`w-4 h-4 ${refreshFeedMutation.isPending ? 'animate-spin' : ''}`}
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
+              <div className="flex w-full items-center gap-3 sm:w-auto sm:flex-1 sm:flex-wrap">
+                {requireAuth && isAdmin && !isMember && (
+                  <button
+                    onClick={() => joinFeedMutation.mutate()}
+                    disabled={joinFeedMutation.isPending}
+                    className={`flex h-11 flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 font-medium whitespace-nowrap transition-colors sm:h-auto sm:flex-none ${
+                      joinFeedMutation.isPending
+                        ? 'bg-blue-100 text-blue-300 cursor-not-allowed'
+                        : 'bg-blue-600 text-white hover:bg-blue-700'
+                    }`}
                   >
-                    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
-                    <path d="M21 3v6h-6" />
-                  </svg>
-                  <span>Refresh Feed</span>
-                </button>
-              )}
+                    <svg className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                    </svg>
+                    <span>Join feed</span>
+                  </button>
+                )}
 
-              {/* Settings Button (cog) */}
-              {isAdmin && (
-                <button
-                  onClick={() => setShowSettingsModal(true)}
-                  title="Feed settings"
-                  className="w-10 h-10 rounded-lg bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-600 hover:text-gray-800 transition-colors"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                </button>
-              )}
+                {canModifyEpisodes && (
+                  <button
+                    onClick={() => refreshFeedMutation.mutate()}
+                    disabled={refreshFeedMutation.isPending}
+                    title="Refresh feed from source"
+                    className={`flex h-11 flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 font-medium whitespace-nowrap transition-colors sm:h-auto sm:flex-none ${
+                      refreshFeedMutation.isPending
+                        ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    <svg
+                      className={`h-4 w-4 shrink-0 ${refreshFeedMutation.isPending ? 'animate-spin' : ''}`}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                      <path d="M21 3v6h-6" />
+                    </svg>
+                    <span>Refresh Feed</span>
+                  </button>
+                )}
 
-              {/* Ellipsis Menu */}
-              <div className="relative menu-container">
-                <button
-                  onClick={() => setShowMenu(!showMenu)}
-                  className="w-10 h-10 rounded-lg bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-600 hover:text-gray-800 transition-colors"
-                >
-                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
-                  </svg>
-                </button>
+                {/* Settings Button (cog) */}
+                {isAdmin && (
+                  <button
+                    onClick={() => setShowSettingsModal(true)}
+                    title="Feed settings"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200 hover:text-gray-800"
+                  >
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                  </button>
+                )}
 
-                {/* Dropdown Menu */}
-                {showMenu && (
-                  <div className="absolute top-full right-0 mt-1 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-20 max-w-[calc(100vw-2rem)]">
+                {/* Ellipsis Menu */}
+                <div className="relative menu-container shrink-0">
+                  <button
+                    onClick={() => setShowMenu(!showMenu)}
+                    className="flex h-11 w-11 items-center justify-center rounded-lg bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200 hover:text-gray-800"
+                  >
+                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+                    </svg>
+                  </button>
+
+                  {/* Dropdown Menu */}
+                  {showMenu && (
+                    <div className="absolute top-full right-0 mt-1 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-20 max-w-[calc(100vw-2rem)]">
                       {canBulkModifyEpisodes && (
                         <>
                           <button
@@ -919,8 +920,9 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                         </button>
                       </>
                     )}
-                  </div>
-                )}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -1164,16 +1166,14 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
 
                     {/* Bottom Controls - only show if episode is whitelisted */}
                     {episode.whitelisted && (
-                      <div className="flex items-center justify-between">
-                        {/* Left side: Download buttons */}
-                        <div className="flex items-center gap-2">
+                      <div className="flex flex-wrap items-start gap-2 sm:items-center">
                           <DownloadButton
                             episodeGuid={episode.guid}
                             isWhitelisted={episode.whitelisted}
                             hasProcessedAudio={episode.has_processed_audio}
                             feedId={currentFeed.id}
                             canModifyEpisodes={canModifyEpisodes}
-                            className="min-w-[100px]"
+                            className="min-w-[100px] shrink-0"
                           />
 
                           <EpisodeProcessingStatus
@@ -1188,17 +1188,13 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                             hasProcessedAudio={episode.has_processed_audio}
                             adDetectionStrategy={currentFeed.ad_detection_strategy}
                           />
-                        </div>
 
-                        {/* Right side: Play button */}
-                        <div className="flex-shrink-0 w-12 flex justify-end">
-                          {episode.has_processed_audio && (
-                            <PlayButton
-                              episode={episode}
-                              className="ml-2"
-                            />
-                          )}
-                        </div>
+                        {episode.has_processed_audio && (
+                          <PlayButton
+                            episode={episode}
+                            className="shrink-0 sm:ml-auto"
+                          />
+                        )}
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/FeedDetail.tsx
+++ b/frontend/src/components/FeedDetail.tsx
@@ -1166,7 +1166,8 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
 
                     {/* Bottom Controls - only show if episode is whitelisted */}
                     {episode.whitelisted && (
-                      <div className="flex flex-wrap items-start gap-2 sm:items-center">
+                      <div className="flex items-center gap-2">
+                        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                           <DownloadButton
                             episodeGuid={episode.guid}
                             isWhitelisted={episode.whitelisted}
@@ -1188,11 +1189,12 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
                             hasProcessedAudio={episode.has_processed_audio}
                             adDetectionStrategy={currentFeed.ad_detection_strategy}
                           />
+                        </div>
 
                         {episode.has_processed_audio && (
                           <PlayButton
                             episode={episode}
-                            className="shrink-0 sm:ml-auto"
+                            className="ml-auto shrink-0"
                           />
                         )}
                       </div>

--- a/frontend/src/components/FeedList.tsx
+++ b/frontend/src/components/FeedList.tsx
@@ -1,15 +1,79 @@
 import { useMemo, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import type { Feed } from '../types';
+import type { FeedSortOption } from '../utils/feedListSort';
+
+function getLatestEpisodeTimestamp(feed: Feed): number | null {
+  if (!feed.latest_episode_release_date) {
+    return null;
+  }
+
+  const timestamp = new Date(feed.latest_episode_release_date).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function compareFeedsByLatestEpisode(
+  leftFeed: Feed,
+  rightFeed: Feed,
+  direction: 'asc' | 'desc'
+): number {
+  const leftTimestamp = getLatestEpisodeTimestamp(leftFeed);
+  const rightTimestamp = getLatestEpisodeTimestamp(rightFeed);
+
+  if (leftTimestamp === null && rightTimestamp === null) {
+    return 0;
+  }
+  if (leftTimestamp === null) {
+    return 1;
+  }
+  if (rightTimestamp === null) {
+    return -1;
+  }
+
+  return direction === 'asc'
+    ? leftTimestamp - rightTimestamp
+    : rightTimestamp - leftTimestamp;
+}
+
+function compareFeedsByTitle(
+  leftFeed: Feed,
+  rightFeed: Feed,
+  direction: 'asc' | 'desc'
+): number {
+  const comparison = leftFeed.title.localeCompare(rightFeed.title, undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
+  return direction === 'asc' ? comparison : -comparison;
+}
+
+function compareFeedsByAddedOrder(
+  leftFeed: Feed,
+  rightFeed: Feed,
+  direction: 'asc' | 'desc'
+): number {
+  // Tech debt: Feed does not expose a true created_at yet, so we use the
+  // autoincrementing id as a proxy for "feed added" ordering for now.
+  return direction === 'asc'
+    ? leftFeed.id - rightFeed.id
+    : rightFeed.id - leftFeed.id;
+}
 
 interface FeedListProps {
   feeds: Feed[];
   onFeedDeleted: () => void;
   onFeedSelected: (feed: Feed) => void;
   selectedFeedId?: number;
+  sortBy: FeedSortOption;
 }
 
-export default function FeedList({ feeds, onFeedDeleted: _onFeedDeleted, onFeedSelected, selectedFeedId }: FeedListProps) {
+export default function FeedList({
+  feeds,
+  onFeedDeleted: _onFeedDeleted,
+  onFeedSelected,
+  selectedFeedId,
+  sortBy,
+}: FeedListProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const { requireAuth, user } = useAuth();
   const showMembership = Boolean(requireAuth && user?.role === 'admin');
@@ -17,17 +81,72 @@ export default function FeedList({ feeds, onFeedDeleted: _onFeedDeleted, onFeedS
   // Ensure feeds is an array
   const feedsArray = Array.isArray(feeds) ? feeds : [];
 
-  const filteredFeeds = useMemo(() => {
+  const displayedFeeds = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
-    if (!term) {
-      return feedsArray;
-    }
-    return feedsArray.filter((feed) => {
-      const title = feed.title?.toLowerCase() ?? '';
-      const author = feed.author?.toLowerCase() ?? '';
-      return title.includes(term) || author.includes(term);
-    });
-  }, [feedsArray, searchTerm]);
+    return feedsArray
+      .map((feed, index) => ({ feed, index }))
+      .filter(({ feed }) => {
+        if (!term) {
+          return true;
+        }
+
+        const title = feed.title?.toLowerCase() ?? '';
+        const author = feed.author?.toLowerCase() ?? '';
+        return title.includes(term) || author.includes(term);
+      })
+      .sort((left, right) => {
+        let primarySort = 0;
+
+        switch (sortBy) {
+          case 'title-asc':
+            primarySort = compareFeedsByTitle(left.feed, right.feed, 'asc');
+            break;
+          case 'title-desc':
+            primarySort = compareFeedsByTitle(left.feed, right.feed, 'desc');
+            break;
+          case 'feed-added-oldest':
+            primarySort = compareFeedsByAddedOrder(
+              left.feed,
+              right.feed,
+              'asc'
+            );
+            break;
+          case 'feed-added-newest':
+            primarySort = compareFeedsByAddedOrder(
+              left.feed,
+              right.feed,
+              'desc'
+            );
+            break;
+          case 'oldest':
+            primarySort = compareFeedsByLatestEpisode(
+              left.feed,
+              right.feed,
+              'asc'
+            );
+            break;
+          default:
+            primarySort = compareFeedsByLatestEpisode(
+              left.feed,
+              right.feed,
+              'desc'
+            );
+            break;
+        }
+
+        if (primarySort !== 0) {
+          return primarySort;
+        }
+
+        const titleSort = compareFeedsByTitle(left.feed, right.feed, 'asc');
+        if (titleSort !== 0) {
+          return titleSort;
+        }
+
+        return left.index - right.index;
+      })
+      .map(({ feed }) => feed);
+  }, [feedsArray, searchTerm, sortBy]);
 
   if (feedsArray.length === 0) {
     return (
@@ -54,14 +173,14 @@ export default function FeedList({ feeds, onFeedDeleted: _onFeedDeleted, onFeedS
         />
       </div>
       <div className="space-y-2 overflow-y-auto h-full pb-20">
-        {filteredFeeds.length === 0 ? (
+        {displayedFeeds.length === 0 ? (
           <div className="flex h-full items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center">
             <p className="text-sm text-gray-500">
               No podcasts match &quot;{searchTerm}&quot;
             </p>
           </div>
         ) : (
-          filteredFeeds.map((feed) => (
+          displayedFeeds.map((feed) => (
             <div 
               key={feed.id} 
               className={`bg-white rounded-lg shadow border cursor-pointer transition-all hover:shadow-md group dark:bg-slate-900/45 dark:border-slate-700/80 dark:hover:border-slate-500/70 dark:hover:bg-slate-900/70 ${

--- a/frontend/src/components/FeedList.tsx
+++ b/frontend/src/components/FeedList.tsx
@@ -64,8 +64,8 @@ export default function FeedList({ feeds, onFeedDeleted: _onFeedDeleted, onFeedS
           filteredFeeds.map((feed) => (
             <div 
               key={feed.id} 
-              className={`bg-white rounded-lg shadow border cursor-pointer transition-all hover:shadow-md group ${
-                selectedFeedId === feed.id ? 'ring-2 ring-blue-500 border-blue-200' : ''
+              className={`bg-white rounded-lg shadow border cursor-pointer transition-all hover:shadow-md group dark:bg-slate-900/45 dark:border-slate-700/80 dark:hover:border-slate-500/70 dark:hover:bg-slate-900/70 ${
+                selectedFeedId === feed.id ? 'ring-2 ring-blue-500 border-blue-200 dark:ring-1 dark:ring-blue-400/80 dark:border-blue-400/35 dark:bg-slate-900/80' : ''
               }`}
               onClick={() => onFeedSelected(feed)}
             >

--- a/frontend/src/components/LLMProcessingStats.tsx
+++ b/frontend/src/components/LLMProcessingStats.tsx
@@ -163,25 +163,25 @@ export default function LLMProcessingStats({
                       <div>
                         <h3 className="font-semibold text-gray-900 mb-4 text-left">Key Metrics</h3>
                         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                          <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-blue-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-blue-50 to-blue-100 p-4 text-center dark:border-blue-800/70 dark:from-blue-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-blue-600 dark:text-blue-200">
                               {stats.processing_stats?.total_segments || 0}
                             </div>
-                            <div className="text-sm text-blue-800">Transcript Segments</div>
+                            <div className="text-sm text-blue-800 dark:text-blue-100">Transcript Segments</div>
                           </div>
 
-                          <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-green-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-green-50 to-green-100 p-4 text-center dark:border-green-800/70 dark:from-green-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-green-600 dark:text-green-200">
                               {stats.processing_stats?.content_segments || 0}
                             </div>
-                            <div className="text-sm text-green-800">Content Segments</div>
+                            <div className="text-sm text-green-800 dark:text-green-100">Content Segments</div>
                           </div>
 
-                          <div className="bg-gradient-to-br from-red-50 to-red-100 rounded-lg p-4 text-center">
-                            <div className="text-2xl font-bold text-red-600">
+                          <div className="rounded-lg border border-transparent bg-gradient-to-br from-red-50 to-red-100 p-4 text-center dark:border-red-800/70 dark:from-red-950 dark:to-slate-900">
+                            <div className="text-2xl font-bold text-red-600 dark:text-red-200">
                               {stats.processing_stats?.ad_segments_count || 0}
                             </div>
-                            <div className="text-sm text-red-800">Ad Segments Removed</div>
+                            <div className="text-sm text-red-800 dark:text-red-100">Ad Segments Removed</div>
                           </div>
                         </div>
                       </div>

--- a/frontend/src/components/LLMProcessingStats.tsx
+++ b/frontend/src/components/LLMProcessingStats.tsx
@@ -302,6 +302,10 @@ export default function LLMProcessingStats({
                           : 0;
                         const cleanSeconds = Math.max(0, durationSeconds - adTimeSeconds);
                         const timelineTicks = [0, 0.25, 0.5, 0.75, 1];
+                        const timelineTrackClass = 'relative h-3 w-full rounded-full bg-gray-200 overflow-hidden';
+                        const timelineContentOverlayClass = 'absolute inset-0 bg-gradient-to-r from-blue-500/20 via-blue-400/15 to-blue-500/20';
+                        const timelineLegendSwatchClass = 'relative h-2.5 w-5 shrink-0 overflow-hidden rounded-full';
+                        const timelineAdSegmentClass = 'bg-rose-500/70';
 
                         return (
                           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
@@ -339,15 +343,15 @@ export default function LLMProcessingStats({
                                 </div>
                               </div>
 
-                              <div className="relative h-3 w-full rounded-full bg-gray-200 overflow-hidden">
-                                <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 via-blue-400/15 to-blue-500/20" />
+                              <div className={timelineTrackClass}>
+                                <div className={timelineContentOverlayClass} />
                                 {durationSeconds > 0 && adBlocks.map((block, index) => {
                                   const left = Math.max(0, (block.start / durationSeconds) * 100);
                                   const width = Math.max(0.5, ((block.end - block.start) / durationSeconds) * 100);
                                   return (
                                     <div
                                       key={`${block.start}-${block.end}-${index}`}
-                                      className="absolute top-0 h-full rounded-full bg-rose-500/70"
+                                      className={`absolute top-0 h-full rounded-full ${timelineAdSegmentClass}`}
                                       style={{ left: `${left}%`, width: `${width}%` }}
                                     />
                                   );
@@ -362,11 +366,13 @@ export default function LLMProcessingStats({
 
                               <div className="flex items-center gap-4 text-xs text-gray-500">
                                 <span className="flex items-center gap-2">
-                                  <span className="h-2 w-2 rounded-full bg-blue-500" />
+                                  <span className={`${timelineLegendSwatchClass} bg-gray-200`}>
+                                    <span className={timelineContentOverlayClass} />
+                                  </span>
                                   Content
                                 </span>
                                 <span className="flex items-center gap-2">
-                                  <span className="h-2 w-2 rounded-full bg-rose-500" />
+                                  <span className={`${timelineLegendSwatchClass} ${timelineAdSegmentClass}`} />
                                   Ads removed
                                 </span>
                               </div>

--- a/frontend/src/components/ReprocessButton.tsx
+++ b/frontend/src/components/ReprocessButton.tsx
@@ -24,25 +24,24 @@ export default function ReprocessButton({
   const [isReprocessing, setIsReprocessing] = useState(false);
   const [activeMode, setActiveMode] = useState<ReprocessMode | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [showModalMode, setShowModalMode] = useState<ReprocessMode | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [keepTranscript, setKeepTranscript] = useState(true);
   const queryClient = useQueryClient();
 
-  const handleReprocessClick = async (mode: ReprocessMode) => {
+  const handleReprocessClick = () => {
     if (!isWhitelisted) {
       setError('Post must be whitelisted before reprocessing');
       return;
     }
 
-    setShowModalMode(mode);
+    setKeepTranscript(true);
+    setShowModal(true);
   };
 
   const handleConfirmReprocess = async () => {
-    const mode = showModalMode;
-    if (!mode) {
-      return;
-    }
+    const mode: ReprocessMode = keepTranscript ? 'keep-transcript' : 'full';
 
-    setShowModalMode(null);
+    setShowModal(false);
     setIsReprocessing(true);
     setActiveMode(mode);
     setError(null);
@@ -81,63 +80,35 @@ export default function ReprocessButton({
     return null;
   }
 
-  const isKeepTranscriptMode = showModalMode === 'keep-transcript';
-  const modalTitle = isKeepTranscriptMode
-    ? 'Confirm Reprocess (Keep Transcript)'
-    : 'Confirm Reprocess';
-  const modalMessage = isKeepTranscriptMode
-    ? 'Are you sure you want to reprocess this episode while keeping the existing transcript? This will delete processed outputs and restart processing after transcription (if the existing transcript is reusable).'
-    : 'Are you sure you want to reprocess this episode? This will delete the existing processed data and start fresh processing.';
-  const confirmButtonLabel = isKeepTranscriptMode
-    ? 'Reprocess (Keep Transcript)'
-    : 'Reprocess Episode';
-  const keepTranscriptButtonTitle = isReprocessing && activeMode === 'keep-transcript'
+  const buttonTitle = isReprocessing && activeMode === 'keep-transcript'
     ? 'Reprocessing from transcript stage...'
-    : 'Reprocess while preserving the existing transcript and restarting after transcription';
+    : isReprocessing
+      ? 'Clearing data and reprocessing...'
+      : 'Clear processed data and choose whether to reuse the existing transcript in the confirmation modal';
 
   return (
     <div className={`${className}`}>
-      <div className="flex flex-wrap gap-2">
-        <button
-          onClick={() => handleReprocessClick('full')}
-          disabled={isReprocessing}
-          className={`px-3 py-1 text-xs rounded font-medium transition-colors border ${
-            isReprocessing
-              ? 'bg-gray-500 text-white cursor-wait border-gray-500'
-              : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:text-gray-900'
-          }`}
-          title={
-            isReprocessing && activeMode === 'full'
-              ? 'Clearing data and reprocessing...'
-              : 'Clear all processing data and start fresh processing'
-          }
-        >
-          {isReprocessing && activeMode === 'full' ? '⏳ Reprocessing...' : 'Reprocess'}
-        </button>
-
-        <button
-          onClick={() => handleReprocessClick('keep-transcript')}
-          disabled={isReprocessing}
-          className={`px-3 py-1 text-xs rounded font-medium transition-colors border ${
-            isReprocessing
-              ? 'bg-gray-500 text-white cursor-wait border-gray-500'
-              : 'bg-white text-blue-700 border-blue-300 hover:bg-blue-50 hover:border-blue-400'
-          }`}
-          title={keepTranscriptButtonTitle}
-        >
-          {isReprocessing && activeMode === 'keep-transcript' ? (
-            <>
-              <span className="sm:hidden">⏳ Reusing...</span>
-              <span className="hidden sm:inline">⏳ Reprocessing (Transcript)...</span>
-            </>
-          ) : (
-            <>
-              <span className="sm:hidden">Reuse Transcript</span>
-              <span className="hidden sm:inline">Reprocess (Keep Transcript)</span>
-            </>
-          )}
-        </button>
-      </div>
+      <button
+        onClick={handleReprocessClick}
+        disabled={isReprocessing}
+        className={`px-3 py-1 text-xs rounded font-medium transition-colors border ${
+          isReprocessing
+            ? 'bg-gray-500 text-white cursor-wait border-gray-500'
+            : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:text-gray-900'
+        }`}
+        title={buttonTitle}
+      >
+        {isReprocessing && activeMode === 'keep-transcript' ? (
+          <>
+            <span className="sm:hidden">⏳ Reusing...</span>
+            <span className="hidden sm:inline">⏳ Reprocessing (Transcript)...</span>
+          </>
+        ) : isReprocessing ? (
+          '⏳ Reprocessing...'
+        ) : (
+          'Reprocess'
+        )}
+      </button>
 
       {error && (
         <div className="text-xs text-red-600 mt-1">
@@ -146,14 +117,14 @@ export default function ReprocessButton({
       )}
 
       {/* Confirmation Modal */}
-      {showModalMode && (
+      {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg max-w-md w-full overflow-hidden">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b">
-              <h2 className="text-xl font-bold text-gray-900">{modalTitle}</h2>
+              <h2 className="text-xl font-bold text-gray-900">Confirm Reprocess</h2>
               <button
-                onClick={() => setShowModalMode(null)}
+                onClick={() => setShowModal(false)}
                 className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
               >
                 <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -165,13 +136,32 @@ export default function ReprocessButton({
             {/* Content */}
             <div className="p-6">
               <p className="text-gray-700 mb-6">
-                {modalMessage}
+                Are you sure you want to reprocess this episode? This will
+                delete the existing processed data and start processing again.
               </p>
+
+              <label className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 mb-6">
+                <input
+                  type="checkbox"
+                  checked={keepTranscript}
+                  onChange={(event) => setKeepTranscript(event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-gray-900">
+                    Keep existing transcript
+                  </span>
+                  <span className="block text-sm text-gray-600">
+                    Reuse the current transcript and restart after
+                    transcription, if that transcript is still reusable.
+                  </span>
+                </span>
+              </label>
 
               {/* Action Buttons */}
               <div className="flex gap-3 justify-end">
                 <button
-                  onClick={() => setShowModalMode(null)}
+                  onClick={() => setShowModal(false)}
                   className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:border-gray-400 transition-colors"
                 >
                   Cancel
@@ -179,12 +169,14 @@ export default function ReprocessButton({
                 <button
                   onClick={handleConfirmReprocess}
                   className={`px-4 py-2 text-sm font-medium text-white rounded-md transition-colors ${
-                    isKeepTranscriptMode
+                    keepTranscript
                       ? 'bg-blue-600 hover:bg-blue-700'
                       : 'bg-orange-600 hover:bg-orange-700'
                   }`}
                 >
-                  {confirmButtonLabel}
+                  {keepTranscript
+                    ? 'Reprocess Episode (Keep Transcript)'
+                    : 'Reprocess Episode'}
                 </button>
               </div>
             </div>

--- a/frontend/src/components/ReprocessButton.tsx
+++ b/frontend/src/components/ReprocessButton.tsx
@@ -91,6 +91,9 @@ export default function ReprocessButton({
   const confirmButtonLabel = isKeepTranscriptMode
     ? 'Reprocess (Keep Transcript)'
     : 'Reprocess Episode';
+  const keepTranscriptButtonTitle = isReprocessing && activeMode === 'keep-transcript'
+    ? 'Reprocessing from transcript stage...'
+    : 'Reprocess while preserving the existing transcript and restarting after transcription';
 
   return (
     <div className={`${className}`}>
@@ -120,15 +123,19 @@ export default function ReprocessButton({
               ? 'bg-gray-500 text-white cursor-wait border-gray-500'
               : 'bg-white text-blue-700 border-blue-300 hover:bg-blue-50 hover:border-blue-400'
           }`}
-          title={
-            isReprocessing && activeMode === 'keep-transcript'
-              ? 'Reprocessing from transcript stage...'
-              : 'Reprocess while preserving the existing transcript and restarting after transcription'
-          }
+          title={keepTranscriptButtonTitle}
         >
-          {isReprocessing && activeMode === 'keep-transcript'
-            ? '⏳ Reprocessing (Transcript)...'
-            : 'Reprocess (Keep Transcript)'}
+          {isReprocessing && activeMode === 'keep-transcript' ? (
+            <>
+              <span className="sm:hidden">⏳ Reusing...</span>
+              <span className="hidden sm:inline">⏳ Reprocessing (Transcript)...</span>
+            </>
+          ) : (
+            <>
+              <span className="sm:hidden">Reuse Transcript</span>
+              <span className="hidden sm:inline">Reprocess (Keep Transcript)</span>
+            </>
+          )}
         </button>
       </div>
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,63 @@
+import { useTheme } from '../contexts/ThemeContext';
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export default function ThemeToggle({ className = '' }: ThemeToggleProps) {
+  const { isDark, preference, toggleTheme } = useTheme();
+
+  const nextThemeLabel = isDark ? 'light' : 'dark';
+  const title =
+    preference === 'system'
+      ? `Following your OS theme. Switch to ${nextThemeLabel} mode.`
+      : `Switch to ${nextThemeLabel} mode`;
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={`inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${className}`.trim()}
+      aria-label={title}
+      aria-pressed={isDark}
+      title={title}
+    >
+      <span className="sr-only">{title}</span>
+      {isDark ? (
+        <svg
+          className="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2.5" />
+          <path d="M12 19.5V22" />
+          <path d="m4.93 4.93 1.77 1.77" />
+          <path d="m17.3 17.3 1.77 1.77" />
+          <path d="M2 12h2.5" />
+          <path d="M19.5 12H22" />
+          <path d="m4.93 19.07 1.77-1.77" />
+          <path d="m17.3 6.7 1.77-1.77" />
+        </svg>
+      ) : (
+        <svg
+          className="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3c0 .24-.01.48-.01.72A7 7 0 0 0 20.28 12c.24 0 .48-.01.72-.01Z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/config/tabs/AdvancedTab.tsx
+++ b/frontend/src/components/config/tabs/AdvancedTab.tsx
@@ -28,8 +28,8 @@ export default function AdvancedTab() {
             onClick={() => setActiveSubtab(subtab.id)}
             className={`px-3 py-1.5 text-sm rounded-md font-medium transition-colors ${
               activeSubtab === subtab.id
-                ? 'bg-indigo-100 text-indigo-700'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-100 dark:ring-1 dark:ring-indigo-400/40'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100'
             }`}
           >
             {subtab.label}

--- a/frontend/src/contexts/AudioPlayerContext.tsx
+++ b/frontend/src/contexts/AudioPlayerContext.tsx
@@ -91,6 +91,12 @@ export function AudioPlayerProvider({ children }: { children: React.ReactNode })
       
       audioRef.current.src = audioUrl;
       audioRef.current.load();
+
+      // Start playback immediately so the first click both opens the player and plays audio.
+      audioRef.current.play().catch((error) => {
+        dispatch({ type: 'SET_ERROR', payload: 'Failed to play audio' });
+        console.error('Audio play error:', error);
+      });
     } else {
       console.log('audioRef.current is null');
     }
@@ -279,4 +285,4 @@ export function useAudioPlayer() {
     throw new Error('useAudioPlayer must be used within an AudioPlayerProvider');
   }
   return context;
-} 
+}

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,128 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'podly-theme';
+const THEME_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+type ThemeContextValue = {
+  isDark: boolean;
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setPreference: (preference: ThemePreference) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  return window.matchMedia(THEME_MEDIA_QUERY).matches ? 'dark' : 'light';
+}
+
+function readStoredPreference(): ThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+
+  const storedPreference = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (
+    storedPreference === 'system'
+    || storedPreference === 'light'
+    || storedPreference === 'dark'
+  ) {
+    return storedPreference;
+  }
+
+  return 'system';
+}
+
+function applyThemeToDocument(
+  preference: ThemePreference,
+  resolvedTheme: ResolvedTheme,
+) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.classList.toggle('dark', resolvedTheme === 'dark');
+  root.style.colorScheme = resolvedTheme;
+  root.dataset.themePreference = preference;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(readStoredPreference);
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
+
+  const resolvedTheme = preference === 'system' ? systemTheme : preference;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const mediaQueryList = window.matchMedia(THEME_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light');
+    };
+
+    setSystemTheme(mediaQueryList.matches ? 'dark' : 'light');
+    mediaQueryList.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    applyThemeToDocument(preference, resolvedTheme);
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+  }, [preference, resolvedTheme]);
+
+  const toggleTheme = () => {
+    setPreference((currentPreference) => {
+      const activeTheme =
+        currentPreference === 'system' ? systemTheme : currentPreference;
+      return activeTheme === 'dark' ? 'light' : 'dark';
+    });
+  };
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        isDark: resolvedTheme === 'dark',
+        preference,
+        resolvedTheme,
+        setPreference,
+        toggleTheme,
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -375,4 +375,91 @@
   html.dark [class~="text-purple-800"] {
     color: var(--podly-purple-text) !important;
   }
+
+  input.input,
+  select.input,
+  textarea.input {
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid rgb(203 213 225);
+    background-color: rgb(255 255 255);
+    color: rgb(17 24 39);
+    padding: 0.625rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    transition:
+      border-color 150ms ease,
+      background-color 150ms ease,
+      color 150ms ease,
+      box-shadow 150ms ease;
+  }
+
+  input.input::placeholder,
+  select.input::placeholder,
+  textarea.input::placeholder {
+    color: rgb(107 114 128);
+  }
+
+  input.input:focus,
+  select.input:focus,
+  textarea.input:focus {
+    outline: none;
+    border-color: rgb(59 130 246);
+    box-shadow: 0 0 0 3px rgb(59 130 246 / 0.18);
+  }
+
+  html.dark input.input,
+  html.dark select.input,
+  html.dark textarea.input {
+    border-color: rgb(71 85 105);
+    background-color: rgb(15 23 42);
+    color: rgb(241 245 249);
+  }
+
+  html.dark input.input::placeholder,
+  html.dark select.input::placeholder,
+  html.dark textarea.input::placeholder {
+    color: rgb(148 163 184);
+  }
+
+  html.dark input.input:focus,
+  html.dark select.input:focus,
+  html.dark textarea.input:focus {
+    border-color: rgb(96 165 250);
+    box-shadow: 0 0 0 3px rgb(96 165 250 / 0.2);
+  }
+
+  input.input:disabled,
+  select.input:disabled,
+  textarea.input:disabled {
+    cursor: not-allowed;
+    border-color: rgb(203 213 225);
+    background-color: rgb(241 245 249);
+    color: rgb(71 85 105);
+    -webkit-text-fill-color: currentColor;
+    opacity: 1;
+  }
+
+  html.dark input.input:disabled,
+  html.dark select.input:disabled,
+  html.dark textarea.input:disabled {
+    border-color: rgb(71 85 105);
+    background-color: rgb(30 41 59);
+    color: rgb(203 213 225);
+    -webkit-text-fill-color: currentColor;
+    box-shadow: inset 0 0 0 1px rgb(51 65 85 / 0.75);
+    opacity: 1;
+  }
+
+  input.input:disabled::placeholder,
+  select.input:disabled::placeholder,
+  textarea.input:disabled::placeholder {
+    color: rgb(100 116 139);
+  }
+
+  html.dark input.input:disabled::placeholder,
+  html.dark select.input:disabled::placeholder,
+  html.dark textarea.input:disabled::placeholder {
+    color: rgb(148 163 184);
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,17 +45,17 @@
 
   html.dark {
     color-scheme: dark;
-    --podly-bg: rgb(2 6 23);
+    --podly-bg: rgb(4 10 24);
     --podly-surface: rgb(15 23 42);
-    --podly-surface-muted: rgb(15 23 42);
-    --podly-surface-subtle: rgb(30 41 59);
-    --podly-surface-strong: rgb(51 65 85);
-    --podly-border-subtle: rgb(51 65 85);
-    --podly-border-strong: rgb(71 85 105);
+    --podly-surface-muted: rgb(19 28 47);
+    --podly-surface-subtle: rgb(35 48 69);
+    --podly-surface-strong: rgb(49 63 86);
+    --podly-border-subtle: rgb(33 46 67);
+    --podly-border-strong: rgb(48 62 84);
     --podly-text-strong: rgb(248 250 252);
     --podly-text: rgb(226 232 240);
-    --podly-text-soft: rgb(203 213 225);
-    --podly-text-muted: rgb(148 163 184);
+    --podly-text-soft: rgb(214 223 236);
+    --podly-text-muted: rgb(167 180 198);
   }
 
   body {
@@ -77,6 +77,11 @@
   html.dark input::placeholder,
   html.dark textarea::placeholder {
     color: var(--podly-text-muted);
+  }
+
+  html.dark select,
+  html.dark option {
+    color: var(--podly-text-strong);
   }
 }
 
@@ -223,6 +228,23 @@
 
   html.dark [class~="disabled:border-gray-200"]:disabled {
     border-color: var(--podly-border-strong) !important;
+  }
+
+  html.dark [class~="focus:border-blue-500"]:focus {
+    border-color: rgb(96 165 250) !important;
+  }
+
+  html.dark [class~="focus:ring-blue-200"]:focus {
+    --tw-ring-color: rgb(96 165 250 / 0.2) !important;
+  }
+
+  html.dark [class~="focus:ring-blue-500"]:focus {
+    --tw-ring-color: rgb(96 165 250 / 0.35) !important;
+  }
+
+  html.dark [class~="focus:ring-offset-2"]:focus,
+  html.dark [class~="focus-visible:ring-offset-2"]:focus-visible {
+    --tw-ring-offset-color: var(--podly-bg) !important;
   }
 
   html.dark [class~="placeholder:text-gray-500"]::placeholder {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,6 +81,10 @@
 }
 
 @layer components {
+  html.dark [class~="border-transparent"] {
+    border-color: transparent !important;
+  }
+
   html.dark [class~="bg-white"] {
     background-color: var(--podly-surface) !important;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,378 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --podly-bg: rgb(249 250 251);
+    --podly-surface: rgb(255 255 255);
+    --podly-surface-muted: rgb(249 250 251);
+    --podly-surface-subtle: rgb(243 244 246);
+    --podly-surface-strong: rgb(229 231 235);
+    --podly-border-subtle: rgb(229 231 235);
+    --podly-border-strong: rgb(209 213 219);
+    --podly-text-strong: rgb(17 24 39);
+    --podly-text: rgb(55 65 81);
+    --podly-text-soft: rgb(75 85 99);
+    --podly-text-muted: rgb(107 114 128);
+    --podly-red-surface: rgb(127 29 29 / 0.28);
+    --podly-red-surface-strong: rgb(127 29 29 / 0.45);
+    --podly-red-border: rgb(220 38 38);
+    --podly-red-text: rgb(254 202 202);
+    --podly-amber-surface: rgb(120 53 15 / 0.32);
+    --podly-amber-surface-strong: rgb(120 53 15 / 0.45);
+    --podly-amber-border: rgb(217 119 6);
+    --podly-amber-text: rgb(253 230 138);
+    --podly-blue-surface: rgb(30 64 175 / 0.28);
+    --podly-blue-surface-strong: rgb(30 64 175 / 0.42);
+    --podly-blue-border: rgb(59 130 246);
+    --podly-blue-text: rgb(191 219 254);
+    --podly-green-surface: rgb(20 83 45 / 0.28);
+    --podly-green-surface-strong: rgb(20 83 45 / 0.42);
+    --podly-green-border: rgb(34 197 94);
+    --podly-green-text: rgb(187 247 208);
+    --podly-indigo-surface: rgb(67 56 202 / 0.25);
+    --podly-indigo-border: rgb(129 140 248);
+    --podly-indigo-text: rgb(224 231 255);
+    --podly-yellow-surface-strong: rgb(133 77 14 / 0.42);
+    --podly-yellow-border: rgb(234 179 8);
+    --podly-yellow-text: rgb(254 240 138);
+    --podly-purple-surface-strong: rgb(88 28 135 / 0.42);
+    --podly-purple-border: rgb(168 85 247);
+    --podly-purple-text: rgb(233 213 255);
+  }
+
+  html.dark {
+    color-scheme: dark;
+    --podly-bg: rgb(2 6 23);
+    --podly-surface: rgb(15 23 42);
+    --podly-surface-muted: rgb(15 23 42);
+    --podly-surface-subtle: rgb(30 41 59);
+    --podly-surface-strong: rgb(51 65 85);
+    --podly-border-subtle: rgb(51 65 85);
+    --podly-border-strong: rgb(71 85 105);
+    --podly-text-strong: rgb(248 250 252);
+    --podly-text: rgb(226 232 240);
+    --podly-text-soft: rgb(203 213 225);
+    --podly-text-muted: rgb(148 163 184);
+  }
+
+  body {
+    background-color: var(--podly-bg);
+    color: var(--podly-text-strong);
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  #root {
+    background-color: inherit;
+  }
+
+  html.dark *,
+  html.dark ::before,
+  html.dark ::after {
+    border-color: var(--podly-border-subtle);
+  }
+
+  html.dark input::placeholder,
+  html.dark textarea::placeholder {
+    color: var(--podly-text-muted);
+  }
+}
+
+@layer components {
+  html.dark [class~="bg-white"] {
+    background-color: var(--podly-surface) !important;
+  }
+
+  html.dark [class~="bg-white/80"] {
+    background-color: rgb(15 23 42 / 0.82) !important;
+  }
+
+  html.dark [class~="bg-gray-50"] {
+    background-color: var(--podly-surface-muted) !important;
+  }
+
+  html.dark [class~="bg-gray-50/60"] {
+    background-color: rgb(15 23 42 / 0.72) !important;
+  }
+
+  html.dark [class~="bg-gray-50/70"] {
+    background-color: rgb(15 23 42 / 0.82) !important;
+  }
+
+  html.dark [class~="bg-gray-100"] {
+    background-color: var(--podly-surface-subtle) !important;
+  }
+
+  html.dark [class~="bg-gray-200"] {
+    background-color: var(--podly-surface-strong) !important;
+  }
+
+  html.dark [class~="bg-gray-300"] {
+    background-color: rgb(71 85 105) !important;
+  }
+
+  html.dark [class~="from-gray-50"] {
+    --tw-gradient-from: rgb(2 6 23) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(2 6 23 / 0) var(--tw-gradient-to-position) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to) !important;
+  }
+
+  html.dark [class~="to-white"] {
+    --tw-gradient-to: rgb(15 23 42) var(--tw-gradient-to-position) !important;
+  }
+
+  html.dark [class~="border-gray-100"] {
+    border-color: var(--podly-border-subtle) !important;
+  }
+
+  html.dark [class~="border-gray-200"] {
+    border-color: var(--podly-border-strong) !important;
+  }
+
+  html.dark [class~="border-gray-300"] {
+    border-color: rgb(100 116 139) !important;
+  }
+
+  html.dark [class~="border-gray-400"] {
+    border-color: rgb(148 163 184) !important;
+  }
+
+  html.dark [class~="divide-gray-200"] > :not([hidden]) ~ :not([hidden]) {
+    border-color: var(--podly-border-strong) !important;
+  }
+
+  html.dark [class~="text-gray-900"] {
+    color: var(--podly-text-strong) !important;
+  }
+
+  html.dark [class~="text-gray-800"] {
+    color: var(--podly-text) !important;
+  }
+
+  html.dark [class~="text-gray-700"] {
+    color: var(--podly-text) !important;
+  }
+
+  html.dark [class~="text-gray-600"] {
+    color: var(--podly-text-soft) !important;
+  }
+
+  html.dark [class~="text-gray-500"] {
+    color: var(--podly-text-muted) !important;
+  }
+
+  html.dark [class~="text-gray-400"] {
+    color: var(--podly-text-muted) !important;
+  }
+
+  html.dark [class~="hover:text-gray-900"]:hover {
+    color: var(--podly-text-strong) !important;
+  }
+
+  html.dark [class~="hover:text-gray-800"]:hover {
+    color: var(--podly-text-strong) !important;
+  }
+
+  html.dark [class~="hover:text-gray-700"]:hover {
+    color: var(--podly-text) !important;
+  }
+
+  html.dark [class~="hover:text-gray-600"]:hover {
+    color: var(--podly-text-soft) !important;
+  }
+
+  html.dark [class~="hover:bg-gray-50"]:hover {
+    background-color: var(--podly-surface-subtle) !important;
+  }
+
+  html.dark [class~="hover:bg-gray-100"]:hover {
+    background-color: var(--podly-surface-subtle) !important;
+  }
+
+  html.dark [class~="hover:bg-gray-200"]:hover {
+    background-color: var(--podly-surface-strong) !important;
+  }
+
+  html.dark [class~="hover:bg-gray-300"]:hover {
+    background-color: rgb(100 116 139) !important;
+  }
+
+  html.dark [class~="hover:border-gray-300"]:hover {
+    border-color: rgb(100 116 139) !important;
+  }
+
+  html.dark [class~="hover:border-gray-400"]:hover {
+    border-color: rgb(148 163 184) !important;
+  }
+
+  html.dark [class~="disabled:bg-gray-100"]:disabled,
+  html.dark [class~="disabled:bg-gray-300"]:disabled {
+    background-color: var(--podly-surface-subtle) !important;
+  }
+
+  html.dark [class~="disabled:text-gray-500"]:disabled,
+  html.dark [class~="disabled:text-gray-400"]:disabled {
+    color: var(--podly-text-muted) !important;
+  }
+
+  html.dark [class~="disabled:border-gray-200"]:disabled {
+    border-color: var(--podly-border-strong) !important;
+  }
+
+  html.dark [class~="placeholder:text-gray-500"]::placeholder {
+    color: var(--podly-text-muted) !important;
+  }
+
+  html.dark [class~="bg-red-50"] {
+    background-color: var(--podly-red-surface) !important;
+  }
+
+  html.dark [class~="bg-red-100"] {
+    background-color: var(--podly-red-surface-strong) !important;
+  }
+
+  html.dark [class~="border-red-200"] {
+    border-color: var(--podly-red-border) !important;
+  }
+
+  html.dark [class~="border-red-300"] {
+    border-color: rgb(248 113 113) !important;
+  }
+
+  html.dark [class~="text-red-800"],
+  html.dark [class~="text-red-700"],
+  html.dark [class~="text-red-600"] {
+    color: var(--podly-red-text) !important;
+  }
+
+  html.dark [class~="text-red-500"] {
+    color: rgb(252 165 165) !important;
+  }
+
+  html.dark [class~="hover:bg-red-50"]:hover {
+    background-color: var(--podly-red-surface-strong) !important;
+  }
+
+  html.dark [class~="hover:bg-red-100"]:hover {
+    background-color: rgb(127 29 29 / 0.56) !important;
+  }
+
+  html.dark [class~="bg-amber-50"] {
+    background-color: var(--podly-amber-surface) !important;
+  }
+
+  html.dark [class~="bg-amber-50/70"] {
+    background-color: var(--podly-amber-surface-strong) !important;
+  }
+
+  html.dark [class~="bg-amber-100"] {
+    background-color: var(--podly-amber-surface-strong) !important;
+  }
+
+  html.dark [class~="border-amber-100"] {
+    border-color: var(--podly-amber-border) !important;
+  }
+
+  html.dark [class~="border-amber-200"],
+  html.dark [class~="border-amber-300"] {
+    border-color: var(--podly-amber-border) !important;
+  }
+
+  html.dark [class~="text-amber-900"],
+  html.dark [class~="text-amber-800"],
+  html.dark [class~="text-amber-700"] {
+    color: var(--podly-amber-text) !important;
+  }
+
+  html.dark [class~="bg-blue-50"] {
+    background-color: var(--podly-blue-surface) !important;
+  }
+
+  html.dark [class~="bg-blue-50/60"] {
+    background-color: var(--podly-blue-surface-strong) !important;
+  }
+
+  html.dark [class~="bg-blue-100"] {
+    background-color: var(--podly-blue-surface-strong) !important;
+  }
+
+  html.dark [class~="border-blue-100"],
+  html.dark [class~="border-blue-200"],
+  html.dark [class~="border-blue-300"] {
+    border-color: var(--podly-blue-border) !important;
+  }
+
+  html.dark [class~="border-blue-400"] {
+    border-color: rgb(96 165 250) !important;
+  }
+
+  html.dark [class~="border-blue-500"] {
+    border-color: rgb(59 130 246) !important;
+  }
+
+  html.dark [class~="text-blue-900/90"],
+  html.dark [class~="text-blue-900"],
+  html.dark [class~="text-blue-800"],
+  html.dark [class~="text-blue-700"] {
+    color: var(--podly-blue-text) !important;
+  }
+
+  html.dark [class~="hover:bg-blue-50"]:hover {
+    background-color: var(--podly-blue-surface-strong) !important;
+  }
+
+  html.dark [class~="hover:border-blue-400"]:hover {
+    border-color: rgb(96 165 250) !important;
+  }
+
+  html.dark [class~="bg-green-50"] {
+    background-color: var(--podly-green-surface) !important;
+  }
+
+  html.dark [class~="bg-green-100"] {
+    background-color: var(--podly-green-surface-strong) !important;
+  }
+
+  html.dark [class~="border-green-200"],
+  html.dark [class~="border-green-300"] {
+    border-color: var(--podly-green-border) !important;
+  }
+
+  html.dark [class~="text-green-800"],
+  html.dark [class~="text-green-700"],
+  html.dark [class~="text-green-600"] {
+    color: var(--podly-green-text) !important;
+  }
+
+  html.dark [class~="bg-indigo-50"] {
+    background-color: var(--podly-indigo-surface) !important;
+  }
+
+  html.dark [class~="border-indigo-200"] {
+    border-color: var(--podly-indigo-border) !important;
+  }
+
+  html.dark [class~="text-indigo-900"],
+  html.dark [class~="text-indigo-800"],
+  html.dark [class~="text-indigo-700"] {
+    color: var(--podly-indigo-text) !important;
+  }
+
+  html.dark [class~="bg-yellow-100"] {
+    background-color: var(--podly-yellow-surface-strong) !important;
+  }
+
+  html.dark [class~="text-yellow-800"] {
+    color: var(--podly-yellow-text) !important;
+  }
+
+  html.dark [class~="bg-purple-100"] {
+    background-color: var(--podly-purple-surface-strong) !important;
+  }
+
+  html.dark [class~="text-purple-800"] {
+    color: var(--podly-purple-text) !important;
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,6 +5,11 @@ import FeedList from '../components/FeedList';
 import FeedDetail from '../components/FeedDetail';
 import AddFeedForm from '../components/AddFeedForm';
 import type { Feed, ConfigResponse } from '../types';
+import {
+  loadFeedListSortPreference,
+  persistFeedListSortPreference,
+} from '../utils/feedListSort';
+import type { FeedSortOption } from '../utils/feedListSort';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
@@ -18,6 +23,9 @@ export default function HomePage() {
   const location = useLocation();
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedFeed, setSelectedFeed] = useState<Feed | null>(null);
+  const [feedSortBy, setFeedSortBy] = useState<FeedSortOption>(() =>
+    loadFeedListSortPreference()
+  );
   const { requireAuth, user } = useAuth();
 
   const { data: feeds, isLoading, error, refetch } = useQuery({
@@ -133,21 +141,49 @@ export default function HomePage() {
     }
   };
 
+  const handleFeedSortChange = (nextSort: FeedSortOption) => {
+    setFeedSortBy(nextSort);
+    persistFeedListSortPreference(nextSort);
+  };
+
   return (
     <div className="h-full flex flex-col lg:flex-row gap-6">
       {/* Left Panel - Feed List (hidden on mobile when feed is selected) */}
       <div className={`flex-1 lg:max-w-md xl:max-w-lg flex flex-col ${
         selectedFeed ? 'hidden lg:flex' : 'flex'
       }`}>
-        <div className="flex justify-between items-center mb-6 gap-3">
-          <h2 className="text-2xl font-bold text-gray-900">Podcast Feeds</h2>
-          <div className="flex items-center gap-2">
+        <div className="mb-6 flex min-w-0 items-center gap-3">
+          <h2 className="shrink-0 text-2xl font-bold text-gray-900">
+            Podcast Feeds
+          </h2>
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
+            <div className="min-w-0 flex-1">
+              <label htmlFor="feed-sort" className="sr-only">
+                Sort feeds
+              </label>
+              <select
+                id="feed-sort"
+                value={feedSortBy}
+                onChange={(event) =>
+                  handleFeedSortChange(event.target.value as FeedSortOption)
+                }
+                className="h-10 w-full rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 transition-colors hover:bg-gray-50 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                title="Sort podcast feeds"
+              >
+                <option value="newest">Newest Episode</option>
+                <option value="oldest">Oldest Episode</option>
+                <option value="title-asc">Title A-Z</option>
+                <option value="title-desc">Title Z-A</option>
+                <option value="feed-added-oldest">Feed Added (Oldest)</option>
+                <option value="feed-added-newest">Feed Added (Newest)</option>
+              </select>
+            </div>
             {canRefreshAll && (
               <button
                 onClick={() => refreshAllMutation.mutate()}
                 disabled={refreshAllMutation.isPending}
                 title="Refresh all feeds"
-                className={`flex items-center justify-center px-3 py-2 rounded-md border transition-colors ${
+                className={`h-10 w-10 shrink-0 flex items-center justify-center rounded-md border transition-colors ${
                   refreshAllMutation.isPending
                     ? 'border-gray-200 text-gray-400 cursor-not-allowed'
                     : 'border-gray-200 text-gray-600 hover:bg-gray-100'
@@ -171,7 +207,7 @@ export default function HomePage() {
             )}
             <button
               onClick={handleCopyAggregateLink}
-              className="flex items-center justify-center px-3 py-2 rounded-md border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors"
+              className="h-10 w-10 shrink-0 flex items-center justify-center rounded-md border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors"
               title="Copy your aggregate feed URL (last 3 episodes from each feed)"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -186,7 +222,7 @@ export default function HomePage() {
                   setShowAddForm((prev) => !prev);
                 }
               }}
-              className={`px-4 py-2 rounded-md font-medium transition-colors ${
+              className={`h-10 shrink-0 inline-flex items-center justify-center rounded-md px-4 font-medium transition-colors ${
                 planLimitReached
                   ? 'bg-amber-600 hover:bg-amber-700 text-white'
                   : 'bg-blue-600 hover:bg-blue-700 text-white'
@@ -207,6 +243,7 @@ export default function HomePage() {
               navigate(`/feeds/${feed.id}`);
             }}
             selectedFeedId={selectedFeed?.id}
+            sortBy={feedSortBy}
           />
         </div>
       </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -153,11 +153,20 @@ export default function HomePage() {
                     : 'border-gray-200 text-gray-600 hover:bg-gray-100'
                 }`}
               >
-                <img
-                  src="/reload-icon.svg"
-                  alt="Refresh all"
+                <svg
                   className={`w-4 h-4 ${refreshAllMutation.isPending ? 'animate-spin' : ''}`}
-                />
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                  <path d="M21 3v6h-6" />
+                </svg>
+                <span className="sr-only">Refresh all</span>
               </button>
             )}
             <button

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { landingApi } from '../services/api';
+import ThemeToggle from '../components/ThemeToggle';
 
 export default function LandingPage() {
   const { data: status } = useQuery({
@@ -36,9 +37,12 @@ export default function LandingPage() {
                 GitHub
               </a>
             </nav>
-            <Link to="/login" className="bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded-lg font-medium transition-colors shadow-sm">
-              Sign In
-            </Link>
+            <div className="flex items-center gap-3">
+              <ThemeToggle />
+              <Link to="/login" className="bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded-lg font-medium transition-colors shadow-sm">
+                Sign In
+              </Link>
+            </div>
           </div>
         </div>
       </header>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { discordApi } from '../services/api';
+import ThemeToggle from '../components/ThemeToggle';
 
 export default function LoginPage() {
   const { login, landingPageEnabled } = useAuth();
@@ -85,6 +86,9 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="fixed right-4 top-4">
+        <ThemeToggle />
+      </div>
       <div className="w-full max-w-md bg-white shadow-lg rounded-xl border border-gray-200 p-6">
         <div className="flex flex-col items-center gap-2 mb-6">
           <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Feed {
   author?: string;
   image_url?: string;
   posts_count: number;
+  latest_episode_release_date?: string | null;
   member_count?: number;
   is_member?: boolean;
   is_active_subscription?: boolean;

--- a/frontend/src/utils/feedListSort.ts
+++ b/frontend/src/utils/feedListSort.ts
@@ -1,0 +1,39 @@
+export type FeedSortOption =
+  | 'newest'
+  | 'oldest'
+  | 'title-asc'
+  | 'title-desc'
+  | 'feed-added-oldest'
+  | 'feed-added-newest';
+
+const FEED_LIST_SORT_STORAGE_KEY = 'podly:feed-list-sort';
+const VALID_FEED_SORT_OPTIONS = new Set<FeedSortOption>([
+  'newest',
+  'oldest',
+  'title-asc',
+  'title-desc',
+  'feed-added-oldest',
+  'feed-added-newest',
+]);
+
+export function loadFeedListSortPreference(): FeedSortOption {
+  if (typeof window === 'undefined') {
+    return 'newest';
+  }
+
+  const rawValue = window.localStorage.getItem(FEED_LIST_SORT_STORAGE_KEY);
+  if (rawValue === 'title') {
+    return 'title-asc';
+  }
+  return VALID_FEED_SORT_OPTIONS.has(rawValue as FeedSortOption)
+    ? (rawValue as FeedSortOption)
+    : 'newest';
+}
+
+export function persistFeedListSortPreference(sortBy: FeedSortOption): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(FEED_LIST_SORT_STORAGE_KEY, sortBy);
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: 'class',
   theme: {
     extend: {},
   },

--- a/src/app/routes/feed_routes.py
+++ b/src/app/routes/feed_routes.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import secrets
 from pathlib import Path
@@ -851,6 +852,28 @@ def _require_user_or_error(
     return user, None
 
 
+def _latest_episode_release_date(feed: Feed) -> str | None:
+    latest_release_date: datetime.datetime | None = None
+
+    for post in cast(list[Any], getattr(feed, "posts", [])):
+        release_date = getattr(post, "release_date", None)
+        if release_date is None:
+            continue
+
+        normalized_release_date = release_date
+        if normalized_release_date.tzinfo is None:
+            normalized_release_date = normalized_release_date.replace(
+                tzinfo=datetime.UTC
+            )
+        else:
+            normalized_release_date = normalized_release_date.astimezone(datetime.UTC)
+
+        if latest_release_date is None or normalized_release_date > latest_release_date:
+            latest_release_date = normalized_release_date
+
+    return latest_release_date.isoformat() if latest_release_date else None
+
+
 def _serialize_feed(
     feed: Feed,
     *,
@@ -886,6 +909,7 @@ def _serialize_feed(
             feed, "auto_whitelist_new_episodes_override", None
         ),
         "posts_count": len(cast(list[Any], feed.posts)),
+        "latest_episode_release_date": _latest_episode_release_date(feed),
         "member_count": len(member_ids),
         "is_member": is_member,
         "is_active_subscription": is_active_subscription,

--- a/src/tests/test_session_auth.py
+++ b/src/tests/test_session_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import UTC, datetime
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -225,3 +226,63 @@ def test_share_link_prefers_https_from_forwarded_header(auth_app: Flask) -> None
     payload = share.get_json()
     assert payload is not None
     assert payload["url"].startswith("https://")
+
+
+def test_feeds_endpoint_includes_latest_episode_release_date(auth_app: Flask) -> None:
+    client = auth_app.test_client()
+    latest_release_date = datetime(2024, 2, 1, 15, 30, tzinfo=UTC)
+
+    with auth_app.app_context():
+        dated_feed = Feed(title="Dated Feed", rss_url="https://example.com/dated.xml")
+        undated_feed = Feed(
+            title="Undated Feed",
+            rss_url="https://example.com/undated.xml",
+        )
+        db.session.add_all([dated_feed, undated_feed])
+        db.session.commit()
+
+        db.session.add_all(
+            [
+                Post(
+                    feed_id=dated_feed.id,
+                    guid="dated-episode-1",
+                    download_url="https://example.com/dated-episode-1.mp3",
+                    title="Older Episode",
+                    release_date=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+                    whitelisted=True,
+                ),
+                Post(
+                    feed_id=dated_feed.id,
+                    guid="dated-episode-2",
+                    download_url="https://example.com/dated-episode-2.mp3",
+                    title="Newest Episode",
+                    release_date=latest_release_date,
+                    whitelisted=True,
+                ),
+                Post(
+                    feed_id=undated_feed.id,
+                    guid="undated-episode-1",
+                    download_url="https://example.com/undated-episode-1.mp3",
+                    title="Undated Episode",
+                    whitelisted=True,
+                ),
+            ]
+        )
+        db.session.commit()
+
+        dated_feed_id = dated_feed.id
+        undated_feed_id = undated_feed.id
+
+    client.post("/api/auth/login", json={"username": "admin", "password": "password"})
+    response = client.get("/feeds")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+
+    feeds_by_id = {feed["id"]: feed for feed in payload}
+    assert (
+        feeds_by_id[dated_feed_id]["latest_episode_release_date"]
+        == latest_release_date.isoformat()
+    )
+    assert feeds_by_id[undated_feed_id]["latest_episode_release_date"] is None


### PR DESCRIPTION
## Summary
- **This PR includes https://github.com/podly-pure-podcasts/podly_pure_podcasts/pull/205 please review that separately and first!**
- Add dark-mode styling across the app, including stats card contrast and the refresh button icon
- Add a frontend theme provider and sun/moon toggle in the top-right navigation
- Initialize the theme from OS `prefers-color-scheme` and persist the user preference in `localStorage`
- Fix inconsistent mobile button sizing
- Make the first click both reveal the in-page player and actually start playback, instead of needing a second click.
- feat: Add Sorting Behavior to the podcast feed

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## Testing
- [ ] `scripts/ci.sh`
- [x] Not run (explain below)

Frontend-only change. Verified with `mise exec node@20 -- npm run build`.

## Docs
- [x] Not needed
- [ ] Updated (details below)

## Related issues
- None

## Notes
- `mise exec node@20 -- npm run build` passed.
- `mise exec node@20 -- npm run lint` still reports pre-existing unrelated frontend lint issues outside this staged change set.

<img width="1325" height="890" alt="Screenshot 2026-03-30 at 12 41 29 AM" src="https://github.com/user-attachments/assets/4e098e21-cf64-4b82-8de4-3213b849f6bf" />
<img width="988" height="789" alt="Screenshot 2026-03-30 at 12 47 02 AM" src="https://github.com/user-attachments/assets/091c9315-fd01-4f20-b649-b8487e51c0a4" />


## Checklist
- [x] Target branch is `Preview`
- [x] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning
- [x] If merging to main, at least one commit in this PR follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) Please refer to https://www.conventionalcommits.org/en/v1.0.0/#summary for more details.
