### PR TITLE
fix: use original episode duration for ad stats and processing cost

### DIFF
--- a/frontend/src/components/LLMProcessingStats.tsx
+++ b/frontend/src/components/LLMProcessingStats.tsx
@@ -263,10 +263,12 @@ export default function LLMProcessingStats({
                       )}
 
                       {(() => {
-                        const durationSeconds = stats.post?.duration
-                          ?? (stats.transcript_segments?.length
-                            ? Math.max(...stats.transcript_segments.map((segment) => segment.end_time))
-                            : 0);
+                        const durationSeconds = (
+                          stats.processing_stats?.original_duration_seconds
+                          ?? ((stats.post?.duration ?? 0) + (stats.processing_stats?.estimated_ad_time_seconds ?? 0))
+                        ) || (stats.transcript_segments?.length
+                          ? Math.max(...stats.transcript_segments.map((segment) => segment.end_time))
+                          : 0);
                         const fallbackAdBlocks = (() => {
                           const adSegments = (stats.transcript_segments || [])
                             .filter((segment) => segment.primary_label === 'ad')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -283,6 +283,7 @@ export const feedsApi = {
       ad_segments_count: number;
       ad_percentage: number;
       estimated_ad_time_seconds: number;
+      original_duration_seconds: number;
       ad_blocks?: Array<{
         start_time: number;
         end_time: number;
@@ -442,6 +443,7 @@ export const feedsApi = {
       ad_segments_count: number;
       ad_percentage: number;
       estimated_ad_time_seconds: number;
+      original_duration_seconds: number;
       ad_blocks?: Array<{
         start_time: number;
         end_time: number;

--- a/src/app/routes/cost_routes.py
+++ b/src/app/routes/cost_routes.py
@@ -14,7 +14,16 @@ from flask import Blueprint, jsonify, request
 from app.auth.guards import require_admin
 from app.config_store import read_combined
 from app.extensions import db
-from app.models import Feed, Identification, ModelCall, Post, ProcessingJob, TranscriptSegment, User, UserFeed
+from app.models import (
+    Feed,
+    Identification,
+    ModelCall,
+    Post,
+    ProcessingJob,
+    TranscriptSegment,
+    User,
+    UserFeed,
+)
 from app.writer.client import writer_client
 
 logger = logging.getLogger("global_logger")
@@ -118,7 +127,9 @@ def api_admin_costs() -> flask.Response:
         .group_by(TranscriptSegment.post_id)
         .all()
     )
-    ad_time_by_post_id: dict[int, float] = {row[0]: float(row[1]) for row in ad_time_rows}
+    ad_time_by_post_id: dict[int, float] = {
+        row[0]: float(row[1]) for row in ad_time_rows
+    }
 
     # --- Per-user monthly cost breakdown ---
     user_feed_map: dict[int, list[int]] = {}  # user_id -> [feed_id, ...]

--- a/src/app/routes/cost_routes.py
+++ b/src/app/routes/cost_routes.py
@@ -14,7 +14,7 @@ from flask import Blueprint, jsonify, request
 from app.auth.guards import require_admin
 from app.config_store import read_combined
 from app.extensions import db
-from app.models import Feed, ModelCall, Post, ProcessingJob, User, UserFeed
+from app.models import Feed, Identification, ModelCall, Post, ProcessingJob, TranscriptSegment, User, UserFeed
 from app.writer.client import writer_client
 
 logger = logging.getLogger("global_logger")
@@ -23,7 +23,7 @@ costs_bp = Blueprint("costs", __name__)
 
 
 def _compute_cost_per_subscriber(
-    duration_seconds: int, subscriber_count: int, cost_rate: float
+    duration_seconds: float, subscriber_count: int, cost_rate: float
 ) -> float:
     """Cost attributed per subscriber for one episode."""
     if subscriber_count <= 0 or duration_seconds <= 0:
@@ -98,6 +98,28 @@ def api_admin_costs() -> flask.Response:
     )
     post_map: dict[str, Post] = {p.guid: p for p in posts_in_month}
 
+    # Batch-query ad time per post so we can reconstruct original duration.
+    # post.duration is the cut (ad-removed) length; original = cut + ad_time.
+    post_ids = [p.id for p in posts_in_month]
+    ad_segment_subq = (
+        db.session.query(Identification.transcript_segment_id)
+        .filter(Identification.label == "ad")
+        .subquery()
+    )
+    ad_time_rows = (
+        db.session.query(
+            TranscriptSegment.post_id,
+            db.func.sum(TranscriptSegment.end_time - TranscriptSegment.start_time),
+        )
+        .filter(
+            TranscriptSegment.post_id.in_(post_ids),
+            TranscriptSegment.id.in_(ad_segment_subq),
+        )
+        .group_by(TranscriptSegment.post_id)
+        .all()
+    )
+    ad_time_by_post_id: dict[int, float] = {row[0]: float(row[1]) for row in ad_time_rows}
+
     # --- Per-user monthly cost breakdown ---
     user_feed_map: dict[int, list[int]] = {}  # user_id -> [feed_id, ...]
     feed_user_map: dict[int, list[int]] = {}  # feed_id -> [user_id, ...]
@@ -114,7 +136,9 @@ def api_admin_costs() -> flask.Response:
         post = post_map.get(guid)
         if not post:
             continue
-        duration = post.duration or 0
+        cut_duration = float(post.duration or 0)
+        ad_time = ad_time_by_post_id.get(post.id, 0.0)
+        duration = cut_duration + ad_time  # original duration = cut + removed ad time
         feed_id = post.feed_id
         subscriber_count = feed_subscriber_count.get(feed_id, 0)
         cost_per_sub = _compute_cost_per_subscriber(

--- a/src/app/routes/post_routes.py
+++ b/src/app/routes/post_routes.py
@@ -536,12 +536,18 @@ def api_post_stats(p_guid: str) -> flask.Response:
     ad_blocks = merge_time_windows(ad_windows_source, gap_seconds=1.0)
     ad_time_seconds = sum(end - start for start, end in ad_blocks if end > start)
 
-    duration_seconds = float(post.duration or 0)
-    if duration_seconds <= 0 and transcript_segments:
-        duration_seconds = max(float(seg.end_time) for seg in transcript_segments)
+    cut_duration_seconds = float(post.duration or 0)
+    if cut_duration_seconds <= 0 and transcript_segments:
+        cut_duration_seconds = max(float(seg.end_time) for seg in transcript_segments)
+
+    # post.duration is the cut (ad-removed) audio length; reconstruct original by adding
+    # back the removed ad time so the percentage uses the correct denominator.
+    original_duration_seconds = cut_duration_seconds + ad_time_seconds
 
     ad_percentage = (
-        (ad_time_seconds / duration_seconds) * 100 if duration_seconds > 0 else 0.0
+        (ad_time_seconds / original_duration_seconds) * 100
+        if original_duration_seconds > 0
+        else 0.0
     )
 
     stats_data = {
@@ -565,6 +571,7 @@ def api_post_stats(p_guid: str) -> flask.Response:
             "ad_segments_count": ad_segments,
             "ad_percentage": round(ad_percentage, 1),
             "estimated_ad_time_seconds": round(ad_time_seconds, 1),
+            "original_duration_seconds": round(original_duration_seconds, 1),
             "ad_blocks": [
                 {
                     "start_time": round(start, 1),


### PR DESCRIPTION
## Summary
- Fix ad percentage and timeline bar using cut duration instead of original episode duration
- Fix admin cost dashboard using cut duration instead of original for processing cost calculation

## Type of change
- [x] Bug fix

## Testing
- [x] \`scripts/ci.sh\`

Run against the PR branch (\`fix/stats-original-duration\` based on \`origin/preview\`). Ruff, ty, and 266 tests pass. 1 pre-existing failure: \`test_cleanup_preserves_most_recent_across_multiple_feeds\` — confirmed by running the test on a clean checkout of \`origin/preview\` at \`8263d4b\`.

## Docs
- [x] Not needed

## Related issues
- Discovered while investigating incorrect stats on a processed episode (Mount Tambora / History Daily)

## Notes
\`audio_processor.py\` sets \`post.duration\` to the cut (ad-removed) audio length after processing, so RSS feeds serve the correct playable duration to podcast apps. Two places did not account for this and incorrectly used \`post.duration\` as the original episode duration:

1. **Stats** (\`post_routes.py\`, \`LLMProcessingStats.tsx\`, \`api.ts\`): ad percentage was \`ad_time / cut_duration\`; fix reconstructs original as \`cut_duration + ad_time_seconds\`, uses it as the percentage denominator, and returns it as \`original_duration_seconds\` in the API response. The frontend prefers this field for the timeline bar width, falling back to \`post.duration + estimated_ad_time_seconds\`, then to max transcript segment end time. TypeScript type definition updated in \`api.ts\` (two response shapes).

2. **Cost** (\`cost_routes.py\`): Whisper + LLM process the full original audio including ads, so cost scales with original duration. Fix batch-queries ad time per post via a single \`TranscriptSegment × Identification\` aggregation and adds it back to \`post.duration\`. The \`_compute_cost_per_subscriber\` type annotation updated from \`int\` to \`float\` as a result of this change.

## Checklist
- [x] Target branch is \`Preview\`
- [x] Docs updated if needed
- [x] Tests run or explicitly skipped with reasoning
- [x] If merging to main, at least one commit in this PR follows Conventional Commits