### PR TITLE
fix: re-add response_format and handle duplicate JSON keys from local LLMs

### DIFF
--- a/src/podcast_processor/ad_classifier.py
+++ b/src/podcast_processor/ad_classifier.py
@@ -656,6 +656,8 @@ class AdClassifier:
             # For older models and non-OpenAI models, use max_tokens
             completion_args["max_tokens"] = self.config.openai_max_tokens
 
+        completion_args["response_format"] = {"type": "json_object"}
+
         return completion_args
 
     def _generate_user_prompt(

--- a/src/podcast_processor/model_output.py
+++ b/src/podcast_processor/model_output.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 from typing import Literal
@@ -92,6 +93,38 @@ def _attempt_json_repair(json_str: str) -> str:
     return repaired
 
 
+def _merge_duplicate_ad_segments(text: str) -> str:
+    """Merge duplicate ``"ad_segments"`` keys that some local LLMs produce.
+
+    Python's ``json.loads`` silently keeps only the *last* value for duplicate
+    keys, so ``{"ad_segments":[A], "ad_segments":[B]}`` would lose ``[A]``.
+    """
+    if text.count('"ad_segments"') <= 1:
+        return text
+
+    def _merge_pairs(pairs: list[tuple[str, object]]) -> dict:
+        result: dict = {}
+        for key, value in pairs:
+            if key == "ad_segments" and key in result:
+                if isinstance(result[key], list) and isinstance(value, list):
+                    result[key].extend(value)
+                else:
+                    result[key] = value
+            else:
+                result[key] = value
+        return result
+
+    try:
+        merged = json.loads(text, object_pairs_hook=_merge_pairs)
+        logger.warning(
+            "Merged duplicate ad_segments keys (%d occurrences)",
+            text.count('"ad_segments"'),
+        )
+        return json.dumps(merged)
+    except (json.JSONDecodeError, ValueError):
+        return text
+
+
 def clean_and_parse_model_output(model_output: str) -> AdSegmentPredictionList:
     start_marker, end_marker = "{", "}"
 
@@ -113,6 +146,8 @@ def clean_and_parse_model_output(model_output: str) -> AdSegmentPredictionList:
     model_output = model_output.replace("'", '"')
     model_output = model_output.replace("\n", "")
     model_output = model_output.strip()
+
+    model_output = _merge_duplicate_ad_segments(model_output)
 
     # First attempt: try to parse as-is
     try:

--- a/src/tests/test_model_output.py
+++ b/src/tests/test_model_output.py
@@ -1,0 +1,93 @@
+from podcast_processor.model_output import (
+    AdSegmentPredictionList,
+    _merge_duplicate_ad_segments,
+    clean_and_parse_model_output,
+)
+
+
+class TestMergeDuplicateAdSegments:
+    def test_single_key_unchanged(self):
+        text = '{"ad_segments": [{"segment_offset": 30.0, "confidence": 0.95}]}'
+        assert _merge_duplicate_ad_segments(text) == text
+
+    def test_no_ad_segments_unchanged(self):
+        text = '{"other_key": "value"}'
+        assert _merge_duplicate_ad_segments(text) == text
+
+    def test_two_duplicate_keys_merged(self):
+        text = (
+            '{"ad_segments": [{"segment_offset": 30.0, "confidence": 0.95}], '
+            '"ad_segments": [{"segment_offset": 165.4, "confidence": 0.9}]}'
+        )
+        result = _merge_duplicate_ad_segments(text)
+        import json
+
+        parsed = json.loads(result)
+        assert len(parsed["ad_segments"]) == 2
+        assert parsed["ad_segments"][0]["segment_offset"] == 30.0
+        assert parsed["ad_segments"][1]["segment_offset"] == 165.4
+
+    def test_three_duplicate_keys_merged(self):
+        text = (
+            '{"ad_segments": [{"segment_offset": 10.0, "confidence": 0.9}], '
+            '"ad_segments": [{"segment_offset": 50.0, "confidence": 0.8}], '
+            '"ad_segments": [{"segment_offset": 90.0, "confidence": 0.7}]}'
+        )
+        result = _merge_duplicate_ad_segments(text)
+        import json
+
+        parsed = json.loads(result)
+        assert len(parsed["ad_segments"]) == 3
+
+    def test_empty_arrays_handled(self):
+        text = '{"ad_segments": [], "ad_segments": [{"segment_offset": 5.0, "confidence": 0.9}]}'
+        result = _merge_duplicate_ad_segments(text)
+        import json
+
+        parsed = json.loads(result)
+        assert len(parsed["ad_segments"]) == 1
+
+    def test_malformed_json_returned_unchanged(self):
+        text = '{"ad_segments": [broken, "ad_segments": [also broken}'
+        assert _merge_duplicate_ad_segments(text) == text
+
+    def test_preserves_other_fields(self):
+        text = (
+            '{"ad_segments": [{"segment_offset": 10.0, "confidence": 0.9}], '
+            '"confidence": 0.85, '
+            '"ad_segments": [{"segment_offset": 50.0, "confidence": 0.8}]}'
+        )
+        result = _merge_duplicate_ad_segments(text)
+        import json
+
+        parsed = json.loads(result)
+        assert len(parsed["ad_segments"]) == 2
+        assert parsed["confidence"] == 0.85
+
+
+class TestCleanAndParseModelOutput:
+    def test_valid_json(self):
+        text = '{"ad_segments": [{"segment_offset": 30.0, "confidence": 0.95}]}'
+        result = clean_and_parse_model_output(text)
+        assert isinstance(result, AdSegmentPredictionList)
+        assert len(result.ad_segments) == 1
+        assert result.ad_segments[0].segment_offset == 30.0
+
+    def test_duplicate_keys_parsed(self):
+        text = (
+            '{"ad_segments": [{"segment_offset": 30.0, "confidence": 0.95}], '
+            '"ad_segments": [{"segment_offset": 165.4, "confidence": 0.9}]}'
+        )
+        result = clean_and_parse_model_output(text)
+        assert isinstance(result, AdSegmentPredictionList)
+        assert len(result.ad_segments) == 2
+
+    def test_with_markdown_fences(self):
+        text = '```json\n{"ad_segments": [{"segment_offset": 10.0, "confidence": 0.9}]}\n```'
+        result = clean_and_parse_model_output(text)
+        assert len(result.ad_segments) == 1
+
+    def test_empty_ad_segments(self):
+        text = '{"ad_segments": []}'
+        result = clean_and_parse_model_output(text)
+        assert len(result.ad_segments) == 0

--- a/src/tests/test_post_cleanup.py
+++ b/src/tests/test_post_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -17,6 +18,17 @@ from app.post_cleanup import cleanup_processed_posts, count_cleanup_candidates
 
 def _utc_now() -> datetime:
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _set_file_mtime(path: Path, dt: datetime) -> None:
+    """Set a file's mtime to match the given datetime.
+
+    The cleanup code uses file mtime to determine which post is most recent
+    per feed.  Without explicit mtimes every test file gets mtime ≈ now,
+    making the 'most recent' selection non-deterministic.
+    """
+    ts = dt.timestamp()
+    os.utime(path, (ts, ts))
 
 
 def _create_feed() -> Feed:
@@ -55,21 +67,25 @@ def test_cleanup_removes_expired_posts(app, tmp_path) -> None:
             feed, "recent-guid", "https://example.com/recent.mp3"
         )
 
+        completed_at = _utc_now() - timedelta(days=10)
+        recent_completed = _utc_now() - timedelta(days=2)
+
         old_processed = Path(tmp_path) / "old_processed.mp3"
         old_unprocessed = Path(tmp_path) / "old_unprocessed.mp3"
         old_processed.write_text("processed")
         old_unprocessed.write_text("unprocessed")
+        _set_file_mtime(old_processed, completed_at)
+        _set_file_mtime(old_unprocessed, completed_at)
         old_post.processed_audio_path = str(old_processed)
         old_post.unprocessed_audio_path = str(old_unprocessed)
 
         # Give recent post processed audio too so it's in the candidate list
         recent_processed = Path(tmp_path) / "recent_processed.mp3"
         recent_processed.write_text("processed")
+        _set_file_mtime(recent_processed, recent_completed)
         recent_post.processed_audio_path = str(recent_processed)
 
         db.session.commit()
-
-        completed_at = _utc_now() - timedelta(days=10)
         db.session.add(
             ProcessingJob(
                 id="job-old",
@@ -84,7 +100,6 @@ def test_cleanup_removes_expired_posts(app, tmp_path) -> None:
             )
         )
 
-        recent_completed = _utc_now() - timedelta(days=2)
         db.session.add(
             ProcessingJob(
                 id="job-recent",
@@ -186,8 +201,12 @@ def test_cleanup_includes_non_whitelisted_processed_posts(app, tmp_path) -> None
         )
         old_post.whitelisted = False
         old_post.release_date = _utc_now() - timedelta(days=15)
+        old_completed = _utc_now() - timedelta(days=15)
+        recent_completed = _utc_now() - timedelta(days=10)
+
         old_processed = tmp_path / "old_processed.mp3"
         old_processed.write_text("audio")
+        _set_file_mtime(old_processed, old_completed)
         old_post.processed_audio_path = str(old_processed)
 
         recent_post = _create_post(
@@ -197,10 +216,10 @@ def test_cleanup_includes_non_whitelisted_processed_posts(app, tmp_path) -> None
         recent_post.release_date = _utc_now() - timedelta(days=10)
         recent_processed = tmp_path / "recent_processed.mp3"
         recent_processed.write_text("audio")
+        _set_file_mtime(recent_processed, recent_completed)
         recent_post.processed_audio_path = str(recent_processed)
 
         # Add old completed jobs so both posts qualify for cleanup by age
-        old_completed = _utc_now() - timedelta(days=15)
         db.session.add(
             ProcessingJob(
                 id="job-non-white-old",
@@ -215,7 +234,6 @@ def test_cleanup_includes_non_whitelisted_processed_posts(app, tmp_path) -> None
             )
         )
 
-        recent_completed = _utc_now() - timedelta(days=10)
         db.session.add(
             ProcessingJob(
                 id="job-non-white-recent",
@@ -280,16 +298,23 @@ def test_cleanup_preserves_most_recent_post_per_feed(app, tmp_path) -> None:
             feed, "most-recent", "https://example.com/recent.mp3"
         )
 
-        # All posts have processed audio
-        for idx, post in enumerate([oldest_post, old_post, recent_post]):
-            processed = tmp_path / f"processed_{idx}.mp3"
-            processed.write_text("audio")
-            post.processed_audio_path = str(processed)
-
         # All posts completed before retention window (10 days ago)
         oldest_completed = _utc_now() - timedelta(days=20)
         old_completed = _utc_now() - timedelta(days=15)
         recent_completed = _utc_now() - timedelta(days=10)
+
+        # All posts have processed audio with mtimes matching job timestamps
+        for idx, (post, completed_at) in enumerate(
+            [
+                (oldest_post, oldest_completed),
+                (old_post, old_completed),
+                (recent_post, recent_completed),
+            ]
+        ):
+            processed = tmp_path / f"processed_{idx}.mp3"
+            processed.write_text("audio")
+            _set_file_mtime(processed, completed_at)
+            post.processed_audio_path = str(processed)
 
         for post, completed_at in [
             (oldest_post, oldest_completed),
@@ -360,10 +385,21 @@ def test_cleanup_preserves_most_recent_across_multiple_feeds(app, tmp_path) -> N
             feed2, "feed2-recent", "https://example.com/f2recent.mp3"
         )
 
-        # All posts have processed audio
-        for idx, post in enumerate([feed1_old, feed1_recent, feed2_old, feed2_recent]):
+        old_completed = _utc_now() - timedelta(days=10)
+        recent_completed = _utc_now() - timedelta(days=8)
+
+        # All posts have processed audio with mtimes matching job timestamps
+        for idx, (post, ts) in enumerate(
+            [
+                (feed1_old, old_completed),
+                (feed1_recent, recent_completed),
+                (feed2_old, old_completed),
+                (feed2_recent, recent_completed),
+            ]
+        ):
             processed = tmp_path / f"processed_{idx}.mp3"
             processed.write_text("audio")
+            _set_file_mtime(processed, ts)
             post.processed_audio_path = str(processed)
 
         # All completed 10+ days ago (before retention window)
@@ -388,12 +424,12 @@ def test_cleanup_preserves_most_recent_across_multiple_feeds(app, tmp_path) -> N
             db.session.query(ProcessingJob).filter_by(post_guid="feed1-recent").first()
         )
         assert feed1_recent_job is not None
-        feed1_recent_job.completed_at = _utc_now() - timedelta(days=8)
+        feed1_recent_job.completed_at = recent_completed
         feed2_recent_job = (
             db.session.query(ProcessingJob).filter_by(post_guid="feed2-recent").first()
         )
         assert feed2_recent_job is not None
-        feed2_recent_job.completed_at = _utc_now() - timedelta(days=8)
+        feed2_recent_job.completed_at = recent_completed
 
         db.session.commit()
 
@@ -429,11 +465,12 @@ def test_cleanup_with_single_old_post_per_feed(app, tmp_path) -> None:
         # Single post, very old (30 days)
         only_post = _create_post(feed, "only-post", "https://example.com/only.mp3")
 
+        completed_at = _utc_now() - timedelta(days=30)
+
         processed = tmp_path / "processed.mp3"
         processed.write_text("audio")
+        _set_file_mtime(processed, completed_at)
         only_post.processed_audio_path = str(processed)
-
-        completed_at = _utc_now() - timedelta(days=30)
         db.session.add(
             ProcessingJob(
                 id="job-only",


### PR DESCRIPTION
## Summary

Three fixes: two bug fixes for local LLM ad classification (#184, #185) and one flaky test stabilization.

### 1. Re-add `response_format` to ad classification LLM calls (Fixes #184)

**File:** `src/podcast_processor/ad_classifier.py` (+2 lines)

PR #89 added `response_format=AdSegmentPredictionList` to prevent malformed LLM output, but this was lost when `podcast_processor.py` was refactored into `ad_classifier.py`. The `_prepare_api_call()` method now includes `response_format={"type": "json_object"}` in the completion args. Uses `json_object` type (not the Pydantic model) for broad LLM compatibility — Ollama maps this to `format: json`.

### 2. Merge duplicate `ad_segments` JSON keys before parsing (Fixes #185)

**File:** `src/podcast_processor/model_output.py` (+35 lines)

Some local LLMs (e.g., Ollama + Qwen) produce JSON with duplicate `"ad_segments"` keys. Python `json.loads` silently keeps only the **last** value for duplicate keys, dropping earlier detections. Added `_merge_duplicate_ad_segments()` which uses `json.loads` with `object_pairs_hook` to merge all `ad_segments` arrays into one. Falls through gracefully to the existing repair/parse pipeline for malformed JSON that cannot be parsed.

This is defense-in-depth alongside fix 1: `response_format` prevents most malformed output; this merger catches what slips through.

### 3. Stabilize flaky post cleanup tests

**File:** `src/tests/test_post_cleanup.py` (+54/-17 lines)

`test_cleanup_preserves_most_recent_across_multiple_feeds` failed non-deterministically because all test audio files were created at ~the same instant, giving them nearly identical `st_mtime` values. The cleanup code (`post_cleanup.py:_get_processed_file_timestamp`) uses file mtime to determine which post is "most recent" per feed, so the selection was a coin flip depending on filesystem timestamp granularity.

Fix: added `_set_file_mtime()` helper that calls `os.utime()` to set each test file mtime to match its corresponding job `completed_at` timestamp, which mirrors production behavior. Applied across all 5 test functions that create audio files, not just the failing one.

Credit to the diagnosis and approach from the `fix/flaky-post-cleanup-tests` branch on the kevinriste fork.

## Files changed

| File | Change |
|------|--------|
| `src/podcast_processor/ad_classifier.py` | Add `response_format` to completion args |
| `src/podcast_processor/model_output.py` | Add `_merge_duplicate_ad_segments()` function |
| `src/tests/test_model_output.py` | **New file** — 11 unit tests for model output parsing |
| `src/tests/test_post_cleanup.py` | Set explicit file mtimes in all tests using audio files |

## Test plan

- [x] 7 new unit tests for `_merge_duplicate_ad_segments`: single key unchanged, no ad_segments key unchanged, two duplicate keys merged, three duplicate keys merged, empty arrays handled, malformed JSON returned unchanged, other fields preserved
- [x] 4 new unit tests for `clean_and_parse_model_output`: valid JSON, duplicate keys parsed end-to-end, markdown fences, empty ad_segments
- [x] Previously-flaky `test_cleanup_preserves_most_recent_across_multiple_feeds` now passes deterministically
- [x] Full test suite passes: `uv run pytest src/tests/ --disable-warnings` — 279 passed, 3 skipped
- [x] `scripts/ci.sh` passes (ruff format, ruff check, ty check all clean; note: ci.sh pytest step discovers 0 tests due to pre-existing `testpaths = []` in pyproject.toml — unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.ai/code)