### PR TITLE
fix: scope post guid and download_url uniqueness per feed

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -90,10 +90,8 @@ class FeedAccessToken(db.Model):  # type: ignore[name-defined, misc]
 class Post(db.Model):  # type: ignore[name-defined, misc]
     feed_id = db.Column(db.Integer, db.ForeignKey("feed.id"), nullable=False)
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    guid = db.Column(db.Text, unique=True, nullable=False)
-    download_url = db.Column(
-        db.Text, unique=True, nullable=False
-    )  # remote download URL, not podly url
+    guid = db.Column(db.Text, nullable=False)
+    download_url = db.Column(db.Text, nullable=False)
     title = db.Column(db.Text, nullable=False)
     unprocessed_audio_path = db.Column(db.Text)
     processed_audio_path = db.Column(db.Text)
@@ -117,6 +115,13 @@ class Post(db.Model):  # type: ignore[name-defined, misc]
         backref="post",
         lazy="dynamic",
         order_by="TranscriptSegment.sequence_num",
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint("feed_id", "guid", name="uq_post_feed_id_guid"),
+        db.UniqueConstraint(
+            "feed_id", "download_url", name="uq_post_feed_id_download_url"
+        ),
     )
 
     def audio_len_bytes(self) -> int:

--- a/src/app/post_cleanup.py
+++ b/src/app/post_cleanup.py
@@ -39,24 +39,24 @@ def _get_most_recent_posts_per_feed(post_guids: Sequence[str]) -> set[str]:
     latest_completed = _load_latest_completed_map(post_guids)
 
     # Group by feed and find most recent per feed
-    feed_posts: dict[int, tuple[str, datetime | None]] = {}
+    feed_posts: dict[int, tuple[str, datetime | None, int]] = {}
 
     for post in posts:
         timestamp = _get_post_timestamp(post, latest_completed)
 
         if post.feed_id not in feed_posts:
-            feed_posts[post.feed_id] = (post.guid, timestamp)
+            feed_posts[post.feed_id] = (post.guid, timestamp, post.id)
         else:
-            _, current_timestamp = feed_posts[post.feed_id]
-            # Keep the post with the latest timestamp
+            _, current_timestamp, current_id = feed_posts[post.feed_id]
             if timestamp and current_timestamp:
-                if timestamp > current_timestamp:
-                    feed_posts[post.feed_id] = (post.guid, timestamp)
-            elif timestamp:  # Only new post has timestamp
-                feed_posts[post.feed_id] = (post.guid, timestamp)
-            # If neither has timestamp, keep current
+                if timestamp > current_timestamp or (
+                    timestamp == current_timestamp and post.id > current_id
+                ):
+                    feed_posts[post.feed_id] = (post.guid, timestamp, post.id)
+            elif timestamp:
+                feed_posts[post.feed_id] = (post.guid, timestamp, post.id)
 
-    return {guid for guid, _ in feed_posts.values()}
+    return {guid for guid, _, _ in feed_posts.values()}
 
 
 def _get_post_timestamp(

--- a/src/migrations/versions/d4e7f8a9b2c1_scope_post_guid_and_download_url_per_feed.py
+++ b/src/migrations/versions/d4e7f8a9b2c1_scope_post_guid_and_download_url_per_feed.py
@@ -40,11 +40,11 @@ def upgrade():
         ref_table = fk["referred_table"]
         ref_cols = ", ".join(fk["referred_columns"])
         local_cols = ", ".join(fk["constrained_columns"])
-        col_defs.append(f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})")
+        col_defs.append(
+            f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})"
+        )
 
-    col_defs.append(
-        'CONSTRAINT "uq_post_feed_id_guid" UNIQUE (feed_id, guid)'
-    )
+    col_defs.append('CONSTRAINT "uq_post_feed_id_guid" UNIQUE (feed_id, guid)')
     col_defs.append(
         'CONSTRAINT "uq_post_feed_id_download_url" UNIQUE (feed_id, download_url)'
     )
@@ -53,7 +53,9 @@ def upgrade():
     col_names = ", ".join(f'"{c["name"]}"' for c in columns)
 
     conn.execute(sa.text(create_sql))
-    conn.execute(sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"'))
+    conn.execute(
+        sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"')
+    )
     conn.execute(sa.text('DROP TABLE "post"'))
     conn.execute(sa.text('ALTER TABLE "_post_new" RENAME TO "post"'))
 
@@ -85,12 +87,16 @@ def downgrade():
         ref_table = fk["referred_table"]
         ref_cols = ", ".join(fk["referred_columns"])
         local_cols = ", ".join(fk["constrained_columns"])
-        col_defs.append(f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})")
+        col_defs.append(
+            f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})"
+        )
 
     create_sql = f'CREATE TABLE "_post_new" ({", ".join(col_defs)})'
     col_names = ", ".join(f'"{c["name"]}"' for c in columns)
 
     conn.execute(sa.text(create_sql))
-    conn.execute(sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"'))
+    conn.execute(
+        sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"')
+    )
     conn.execute(sa.text('DROP TABLE "post"'))
     conn.execute(sa.text('ALTER TABLE "_post_new" RENAME TO "post"'))

--- a/src/migrations/versions/d4e7f8a9b2c1_scope_post_guid_and_download_url_per_feed.py
+++ b/src/migrations/versions/d4e7f8a9b2c1_scope_post_guid_and_download_url_per_feed.py
@@ -1,0 +1,96 @@
+"""scope post guid and download_url unique constraints per feed
+
+Revision ID: d4e7f8a9b2c1
+Revises: 3e5eebc6b3b1
+Create Date: 2026-04-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "d4e7f8a9b2c1"
+down_revision = "3e5eebc6b3b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = inspector.get_columns("post")
+    fks = inspector.get_foreign_keys("post")
+    pk = inspector.get_pk_constraint("post")
+
+    col_defs = []
+    for col in columns:
+        col_type = col["type"]
+        parts = [f'"{col["name"]}"', str(col_type)]
+        if col["name"] in (pk.get("constrained_columns") or []):
+            parts.append("PRIMARY KEY")
+        if not col.get("nullable", True):
+            parts.append("NOT NULL")
+        if col.get("default") is not None:
+            parts.append(f"DEFAULT {col['default']}")
+        col_defs.append(" ".join(parts))
+
+    for fk in fks:
+        ref_table = fk["referred_table"]
+        ref_cols = ", ".join(fk["referred_columns"])
+        local_cols = ", ".join(fk["constrained_columns"])
+        col_defs.append(f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})")
+
+    col_defs.append(
+        'CONSTRAINT "uq_post_feed_id_guid" UNIQUE (feed_id, guid)'
+    )
+    col_defs.append(
+        'CONSTRAINT "uq_post_feed_id_download_url" UNIQUE (feed_id, download_url)'
+    )
+
+    create_sql = f'CREATE TABLE "_post_new" ({", ".join(col_defs)})'
+    col_names = ", ".join(f'"{c["name"]}"' for c in columns)
+
+    conn.execute(sa.text(create_sql))
+    conn.execute(sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"'))
+    conn.execute(sa.text('DROP TABLE "post"'))
+    conn.execute(sa.text('ALTER TABLE "_post_new" RENAME TO "post"'))
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = inspector.get_columns("post")
+    fks = inspector.get_foreign_keys("post")
+    pk = inspector.get_pk_constraint("post")
+
+    col_defs = []
+    for col in columns:
+        col_type = col["type"]
+        parts = [f'"{col["name"]}"', str(col_type)]
+        if col["name"] in (pk.get("constrained_columns") or []):
+            parts.append("PRIMARY KEY")
+        if not col.get("nullable", True):
+            parts.append("NOT NULL")
+        if col["name"] == "guid":
+            parts.append("UNIQUE")
+        if col["name"] == "download_url":
+            parts.append("UNIQUE")
+        if col.get("default") is not None:
+            parts.append(f"DEFAULT {col['default']}")
+        col_defs.append(" ".join(parts))
+
+    for fk in fks:
+        ref_table = fk["referred_table"]
+        ref_cols = ", ".join(fk["referred_columns"])
+        local_cols = ", ".join(fk["constrained_columns"])
+        col_defs.append(f"FOREIGN KEY({local_cols}) REFERENCES {ref_table} ({ref_cols})")
+
+    create_sql = f'CREATE TABLE "_post_new" ({", ".join(col_defs)})'
+    col_names = ", ".join(f'"{c["name"]}"' for c in columns)
+
+    conn.execute(sa.text(create_sql))
+    conn.execute(sa.text(f'INSERT INTO "_post_new" ({col_names}) SELECT {col_names} FROM "post"'))
+    conn.execute(sa.text('DROP TABLE "post"'))
+    conn.execute(sa.text('ALTER TABLE "_post_new" RENAME TO "post"'))

--- a/src/tests/test_post_cleanup.py
+++ b/src/tests/test_post_cleanup.py
@@ -421,6 +421,54 @@ def test_cleanup_preserves_most_recent_across_multiple_feeds(app, tmp_path) -> N
         assert f2_old.processed_audio_path is None
 
 
+def test_cleanup_tiebreaker_equal_timestamps(app, tmp_path) -> None:
+    """When two posts have identical timestamps, the higher post.id wins."""
+    with app.app_context():
+        feed = _create_feed()
+
+        first_post = _create_post(feed, "first", "https://example.com/first.mp3")
+        second_post = _create_post(feed, "second", "https://example.com/second.mp3")
+        assert second_post.id > first_post.id
+
+        same_time = _utc_now() - timedelta(days=10)
+
+        for idx, post in enumerate([first_post, second_post]):
+            processed = tmp_path / f"tiebreak_{idx}.mp3"
+            processed.write_text("audio")
+            post.processed_audio_path = str(processed)
+
+        for post in [first_post, second_post]:
+            db.session.add(
+                ProcessingJob(
+                    id=f"job-{post.guid}",
+                    post_guid=post.guid,
+                    status="completed",
+                    current_step=4,
+                    total_steps=4,
+                    progress_percentage=100.0,
+                    created_at=same_time,
+                    started_at=same_time,
+                    completed_at=same_time,
+                )
+            )
+
+        db.session.commit()
+
+        count, _ = count_cleanup_candidates(retention_days=5)
+        assert count == 1
+
+        removed = cleanup_processed_posts(retention_days=5)
+        assert removed == 1
+
+        preserved = Post.query.filter_by(guid="second").first()
+        assert preserved is not None
+        assert preserved.processed_audio_path is not None
+
+        cleaned = Post.query.filter_by(guid="first").first()
+        assert cleaned is not None
+        assert cleaned.processed_audio_path is None
+
+
 def test_cleanup_with_single_old_post_per_feed(app, tmp_path) -> None:
     """Test that a feed with only one post keeps it, even if very old."""
     with app.app_context():


### PR DESCRIPTION
## Summary
- Replace global `UNIQUE` constraints on `Post.guid` and `Post.download_url` with composite constraints scoped per feed: `(feed_id, guid)` and `(feed_id, download_url)`, fixing 500 errors when adding feeds with cross-posted episodes
- Fix non-deterministic tiebreaker in `_get_most_recent_posts_per_feed` when post timestamps are equal, using `post.id` as a stable tiebreaker

Fixes #186
Fixes #192

## Type of change
- [x] Bug fix

## Details

### Constraint change (`src/app/models.py`)
Removed column-level `unique=True` from `Post.guid` and `Post.download_url`. Added `__table_args__` with two composite `UniqueConstraint`s: `(feed_id, guid)` and `(feed_id, download_url)`. This allows the same episode to exist under multiple feeds while still preventing true duplicates within a single feed.

### Migration (`src/migrations/versions/d4e7f8a9b2c1_...`)
Uses raw SQL table recreation instead of Alembic batch mode because SQLite reflects inline `UNIQUE` constraints with `name=None`, which Alembic's `batch_alter_table` cannot drop. The migration reflects the existing table schema via `inspector`, rebuilds the `CREATE TABLE` SQL with the new composite constraints, copies data, drops the old table, and renames. The downgrade reverses this, restoring column-level `UNIQUE` on `guid` and `download_url`.

**Note:** This migration was hand-written rather than auto-generated via `create_migration.sh` due to the SQLite-specific table recreation requirement.

### Tiebreaker fix (`src/app/post_cleanup.py`)
`_get_most_recent_posts_per_feed` did not handle the case where two posts in the same feed have equal timestamps — it would silently keep whichever was iterated first, which is non-deterministic. Added `post.id` (auto-incrementing PK) as a tiebreaker: when timestamps are equal, the higher ID (more recently inserted) wins. This resolved 2 pre-existing flaky test failures.

### Relationship to PR #208
PR #208 addresses the same flaky test symptom from the test side by setting explicit file `mtime` values via `os.utime()`. The two fixes are **complementary, not conflicting** — #208 makes the tests deterministic, this PR makes the production code deterministic. There are no file-level merge conflicts (this PR modifies `post_cleanup.py`, #208 modifies `test_post_cleanup.py`). Both should merge.

## Files changed

| File | Change |
|------|--------|
| `src/app/models.py` | Replace column-level `unique=True` with composite `UniqueConstraint` in `__table_args__` |
| `src/app/post_cleanup.py` | Add `post.id` tiebreaker to `_get_most_recent_posts_per_feed` |
| `src/migrations/versions/d4e7f8a9b2c1_...py` | New migration: raw SQL table recreation for SQLite constraint swap |
| `src/tests/test_post_cleanup.py` | New test: `test_cleanup_tiebreaker_equal_timestamps` for the equal-timestamp tiebreaker behavior |

## Follow-up
- #210 — Scope post route lookups by `feed_id` (route handlers currently look up posts by `guid` alone, which returns non-deterministic results if GUIDs collide across feeds with different audio content)

## Test plan
- [x] `scripts/ci.sh` passes (ruff format, ruff check, ty check all clean; pytest step discovers 0 tests due to pre-existing `testpaths = []` in pyproject.toml — unrelated to this PR)
- [x] `uv run pytest src/tests/ --disable-warnings` — 264 passed, 3 skipped (5 pre-existing `test_process_audio.py` failures due to missing ffmpeg in test environment — unrelated to this PR)
- [x] All 8 post_cleanup tests pass deterministically, including new `test_cleanup_tiebreaker_equal_timestamps`
- [ ] Manually add two feeds with overlapping episodes (e.g., "The News Agents" UK and USA, or "Behind the Bastards" and "It Could Happen Here") — verify no 500 error
- [ ] Verify existing feeds and episodes still display correctly after migration
- [ ] Run migration on a copy of production database

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)