### PR TITLE
fix: set step_name on cancelled jobs

### DIFF
--- a/src/app/jobs_manager.py
+++ b/src/app/jobs_manager.py
@@ -268,6 +268,7 @@ class JobsManager:
                 response["error"] = job.error_message
             if job.status == "cancelled" and job.error_message:
                 response["message"] = job.error_message
+                response["step_name"] = job.error_message
             return response
 
     def get_job_status(self, job_id: str) -> dict[str, Any]:

--- a/src/app/writer/actions/cleanup.py
+++ b/src/app/writer/actions/cleanup.py
@@ -56,7 +56,7 @@ def cleanup_missing_audio_paths_action(params: dict[str, Any]) -> int:
                 .order_by(ProcessingJob.created_at.desc())
                 .first()
             )
-            if latest_job and latest_job.status not in {"pending", "running"}:
+            if latest_job and latest_job.status == "failed":
                 latest_job.status = "pending"
                 latest_job.current_step = 0
                 latest_job.progress_percentage = 0.0

--- a/src/app/writer/actions/cleanup.py
+++ b/src/app/writer/actions/cleanup.py
@@ -56,7 +56,7 @@ def cleanup_missing_audio_paths_action(params: dict[str, Any]) -> int:
                 .order_by(ProcessingJob.created_at.desc())
                 .first()
             )
-            if latest_job and latest_job.status == "failed":
+            if latest_job and latest_job.status not in {"pending", "running"}:
                 latest_job.status = "pending"
                 latest_job.current_step = 0
                 latest_job.progress_percentage = 0.0

--- a/src/app/writer/actions/jobs.py
+++ b/src/app/writer/actions/jobs.py
@@ -167,13 +167,14 @@ def update_job_status_action(params: dict[str, Any]) -> dict[str, Any]:
 
 def mark_cancelled_action(params: dict[str, Any]) -> dict[str, Any]:
     job_id = params.get("job_id")
-    reason = params.get("reason")
+    reason = params.get("reason") or "Cancelled by user request"
 
     job = db.session.get(ProcessingJob, job_id)
     if not job:
         raise ValueError(f"Job {job_id} not found")
 
     job.status = "cancelled"
+    job.step_name = reason
     job.error_message = reason
     job.completed_at = datetime.now(UTC).replace(tzinfo=None)
 

--- a/src/tests/test_cleanup_requeue_and_cancel.py
+++ b/src/tests/test_cleanup_requeue_and_cancel.py
@@ -29,8 +29,11 @@ def _create_feed_and_post(app, *, guid="test-guid", audio_path="/tmp/nonexistent
     return feed, post
 
 
-class TestCleanupOnlyRequeuesFailed:
-    def test_completed_job_not_requeued(self, app):
+class TestCleanupRequeuesWhenAudioMissing:
+    """Whitelisted posts with missing audio should be re-queued for reprocessing
+    regardless of previous job status (except pending/running which are already active)."""
+
+    def test_completed_job_requeued(self, app):
         with app.app_context():
             _, post = _create_feed_and_post(app)
             job = ProcessingJob(
@@ -45,26 +48,10 @@ class TestCleanupOnlyRequeuesFailed:
             db.session.commit()
             db.session.refresh(job)
 
-            assert job.status == "completed"
+            assert job.status == "pending"
+            assert job.step_name == "Not started"
 
-    def test_skipped_job_not_requeued(self, app):
-        with app.app_context():
-            _, post = _create_feed_and_post(app, guid="skipped-guid")
-            job = ProcessingJob(
-                post_guid=post.guid,
-                status="skipped",
-                completed_at=datetime.now(UTC).replace(tzinfo=None),
-            )
-            db.session.add(job)
-            db.session.commit()
-
-            cleanup_missing_audio_paths_action({})
-            db.session.commit()
-            db.session.refresh(job)
-
-            assert job.status == "skipped"
-
-    def test_failed_job_is_requeued(self, app):
+    def test_failed_job_requeued(self, app):
         with app.app_context():
             _, post = _create_feed_and_post(app, guid="failed-guid")
             job = ProcessingJob(
@@ -84,14 +71,13 @@ class TestCleanupOnlyRequeuesFailed:
             assert job.error_message is None
             assert job.step_name == "Not started"
 
-    def test_cancelled_job_not_requeued(self, app):
+    def test_pending_job_not_reset(self, app):
         with app.app_context():
-            _, post = _create_feed_and_post(app, guid="cancelled-guid")
+            _, post = _create_feed_and_post(app, guid="pending-guid")
             job = ProcessingJob(
                 post_guid=post.guid,
-                status="cancelled",
-                error_message="User cancelled",
-                completed_at=datetime.now(UTC).replace(tzinfo=None),
+                status="pending",
+                step_name="Queued",
             )
             db.session.add(job)
             db.session.commit()
@@ -100,7 +86,8 @@ class TestCleanupOnlyRequeuesFailed:
             db.session.commit()
             db.session.refresh(job)
 
-            assert job.status == "cancelled"
+            assert job.status == "pending"
+            assert job.step_name == "Queued"
 
 
 class TestMarkCancelledAction:

--- a/src/tests/test_cleanup_requeue_and_cancel.py
+++ b/src/tests/test_cleanup_requeue_and_cancel.py
@@ -1,0 +1,133 @@
+from datetime import UTC, datetime
+
+from app.extensions import db
+from app.models import Feed, Post, ProcessingJob
+from app.writer.actions.cleanup import cleanup_missing_audio_paths_action
+from app.writer.actions.jobs import mark_cancelled_action
+
+
+def _create_feed_and_post(app, *, guid="test-guid", audio_path="/tmp/nonexistent.mp3"):
+    feed = Feed(
+        title="Test Feed",
+        description="desc",
+        author="author",
+        rss_url="https://example.com/feed.xml",
+    )
+    db.session.add(feed)
+    db.session.commit()
+
+    post = Post(
+        guid=guid,
+        title="Test Episode",
+        download_url="https://example.com/ep.mp3",
+        feed_id=feed.id,
+        whitelisted=True,
+        unprocessed_audio_path=audio_path,
+    )
+    db.session.add(post)
+    db.session.commit()
+    return feed, post
+
+
+class TestCleanupOnlyRequeuesFailed:
+    def test_completed_job_not_requeued(self, app):
+        with app.app_context():
+            _, post = _create_feed_and_post(app)
+            job = ProcessingJob(
+                post_guid=post.guid,
+                status="completed",
+                completed_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+            db.session.add(job)
+            db.session.commit()
+
+            cleanup_missing_audio_paths_action({})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "completed"
+
+    def test_skipped_job_not_requeued(self, app):
+        with app.app_context():
+            _, post = _create_feed_and_post(app, guid="skipped-guid")
+            job = ProcessingJob(
+                post_guid=post.guid,
+                status="skipped",
+                completed_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+            db.session.add(job)
+            db.session.commit()
+
+            cleanup_missing_audio_paths_action({})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "skipped"
+
+    def test_failed_job_is_requeued(self, app):
+        with app.app_context():
+            _, post = _create_feed_and_post(app, guid="failed-guid")
+            job = ProcessingJob(
+                post_guid=post.guid,
+                status="failed",
+                error_message="some error",
+                completed_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+            db.session.add(job)
+            db.session.commit()
+
+            cleanup_missing_audio_paths_action({})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "pending"
+            assert job.error_message is None
+            assert job.step_name == "Not started"
+
+    def test_cancelled_job_not_requeued(self, app):
+        with app.app_context():
+            _, post = _create_feed_and_post(app, guid="cancelled-guid")
+            job = ProcessingJob(
+                post_guid=post.guid,
+                status="cancelled",
+                error_message="User cancelled",
+                completed_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+            db.session.add(job)
+            db.session.commit()
+
+            cleanup_missing_audio_paths_action({})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "cancelled"
+
+
+class TestMarkCancelledAction:
+    def test_sets_step_name(self, app):
+        with app.app_context():
+            job = ProcessingJob(post_guid="cancel-test", status="running")
+            db.session.add(job)
+            db.session.commit()
+
+            mark_cancelled_action({"job_id": job.id, "reason": "Duplicate episode"})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "cancelled"
+            assert job.step_name == "Duplicate episode"
+            assert job.error_message == "Duplicate episode"
+
+    def test_default_reason_when_none(self, app):
+        with app.app_context():
+            job = ProcessingJob(post_guid="cancel-default", status="running")
+            db.session.add(job)
+            db.session.commit()
+
+            mark_cancelled_action({"job_id": job.id})
+            db.session.commit()
+            db.session.refresh(job)
+
+            assert job.status == "cancelled"
+            assert job.step_name == "Cancelled by user request"
+            assert job.error_message == "Cancelled by user request"


### PR DESCRIPTION
## Summary

- `mark_cancelled_action` was not setting `step_name`, causing the UI to show stale step labels (e.g. "Transcribing...") for cancelled jobs. Now sets `step_name` to the cancellation reason and defaults to "Cancelled by user request" when no reason is provided.
- `get_post_status` now returns `step_name` for cancelled jobs so the frontend displays the cancellation reason instead of a stale processing step.

## Changes

- `src/app/writer/actions/jobs.py`: Added `job.step_name = reason` in `mark_cancelled_action` and defaulted reason to "Cancelled by user request"
- `src/app/jobs_manager.py`: Added `step_name` to the cancelled job response in `get_post_status`
- `src/tests/test_cleanup_requeue_and_cancel.py`: 5 new tests covering the cancel fixes and the existing cleanup re-queue behavior

## Test plan

- [x] Cancelled jobs have step_name set to the cancellation reason
- [x] Cancelled jobs default to "Cancelled by user request" when no reason given
- [x] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.ai/code)