### PR TITLE
feat: prevent auto-whitelisting back-catalog episodes on refresh

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -337,6 +337,28 @@ def fetch_feed(url: str) -> feedparser.FeedParserDict:
     return feed_data
 
 
+def _should_whitelist_new_post(
+    feed: Feed, post: Post, floor_date: datetime.date | None
+) -> bool:
+    if floor_date is not None and post.release_date is None:
+        logger.debug(
+            "skipping post without release_date for existing feed: %s",
+            post.title,
+        )
+        return False
+    if (
+        floor_date is not None
+        and post.release_date
+        and post.release_date.date() < floor_date
+    ):
+        logger.debug(
+            "skipping post from archive older than floor date: %s",
+            post.title,
+        )
+        return False
+    return _should_auto_whitelist_new_posts(feed, post)
+
+
 def refresh_feed(feed: Feed) -> None:
     logger.info(f"Refreshing feed with ID: {feed.id}")
     feed_data = fetch_feed(feed.rss_url)
@@ -354,6 +376,27 @@ def refresh_feed(feed: Feed) -> None:
         key=lambda p: p.release_date,
         default=None,
     )
+    oldest_whitelisted_post = min(
+        (
+            post
+            for post in feed.posts  # type: ignore[attr-defined]
+            if post.whitelisted and post.release_date
+        ),
+        key=lambda p: p.release_date,
+        default=None,
+    )
+    oldest_known_date = oldest_post.release_date.date() if oldest_post else None
+    oldest_whitelisted_date = (
+        oldest_whitelisted_post.release_date.date() if oldest_whitelisted_post else None
+    )
+
+    # Use the stricter (more recent) floor date to prevent historical
+    # back-catalog episodes from being auto-whitelisted during refresh.
+    floor_date = (
+        max(oldest_known_date, oldest_whitelisted_date)
+        if oldest_known_date and oldest_whitelisted_date
+        else (oldest_known_date or oldest_whitelisted_date)
+    )
 
     new_posts = []
     existing_post_updates = []
@@ -362,20 +405,7 @@ def refresh_feed(feed: Feed) -> None:
         if existing_post is None:
             logger.debug("found new podcast: %s", entry.title)
             p = make_post(feed, entry)
-            # do not allow automatic download of any backcatalog added to the feed
-            if (
-                oldest_post is not None
-                and p.release_date
-                and oldest_post.release_date
-                and p.release_date.date() < oldest_post.release_date.date()
-            ):
-                p.whitelisted = False
-                logger.debug(
-                    f"skipping post from archive due to \
-number_of_episodes_to_whitelist_from_archive_of_new_feed setting: {entry.title}"
-                )
-            else:
-                p.whitelisted = _should_auto_whitelist_new_posts(feed, p)
+            p.whitelisted = _should_whitelist_new_post(feed, p, floor_date)
 
             post_data = {
                 "guid": p.guid,

--- a/src/tests/test_feeds.py
+++ b/src/tests/test_feeds.py
@@ -343,6 +343,95 @@ def test_refresh_feed_whitelists_when_member_exists(
 @mock.patch("app.feeds._should_auto_whitelist_new_posts")
 @mock.patch("app.feeds.make_post")
 @mock.patch("app.feeds.fetch_feed")
+def test_refresh_feed_blocks_auto_whitelist_for_older_than_whitelisted_floor(
+    mock_fetch_feed,
+    mock_make_post,
+    mock_should_auto_whitelist,
+    mock_writer_client,
+    mock_feed,
+    mock_db_session,
+):
+    existing_very_old = MockPost(
+        guid="existing-very-old",
+        release_date=datetime.datetime(2021, 6, 1, tzinfo=datetime.UTC),
+    )
+    existing_whitelisted_floor = MockPost(
+        guid="existing-whitelisted-floor",
+        release_date=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+    )
+    existing_whitelisted_floor.whitelisted = True
+    mock_feed.posts = [existing_very_old, existing_whitelisted_floor]
+
+    entry = mock.MagicMock()
+    entry.id = "new-backfill-guid"
+    entry.title = "Backfill Episode"
+
+    feed_data = mock.MagicMock()
+    feed_data.feed = mock.MagicMock()
+    feed_data.feed.get.return_value = None
+    feed_data.entries = [entry]
+    mock_fetch_feed.return_value = feed_data
+
+    post_one = MockPost(
+        guid="new-backfill-guid",
+        release_date=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    )
+    mock_make_post.return_value = post_one
+    mock_should_auto_whitelist.return_value = True
+
+    refresh_feed(mock_feed)
+
+    assert post_one.whitelisted is False
+    assert mock_should_auto_whitelist.call_count == 0
+    payload = mock_writer_client.action.call_args.args[1]
+    assert payload["new_posts"][0]["whitelisted"] is False
+
+
+@mock.patch("app.feeds.writer_client")
+@mock.patch("app.feeds._should_auto_whitelist_new_posts")
+@mock.patch("app.feeds.make_post")
+@mock.patch("app.feeds.fetch_feed")
+def test_refresh_feed_blocks_auto_whitelist_when_release_date_missing(
+    mock_fetch_feed,
+    mock_make_post,
+    mock_should_auto_whitelist,
+    mock_writer_client,
+    mock_feed,
+    mock_db_session,
+):
+    existing_whitelisted_floor = MockPost(
+        guid="existing-whitelisted-floor",
+        release_date=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+    )
+    existing_whitelisted_floor.whitelisted = True
+    mock_feed.posts = [existing_whitelisted_floor]
+
+    entry = mock.MagicMock()
+    entry.id = "new-no-date-guid"
+    entry.title = "No Date Episode"
+
+    feed_data = mock.MagicMock()
+    feed_data.feed = mock.MagicMock()
+    feed_data.feed.get.return_value = None
+    feed_data.entries = [entry]
+    mock_fetch_feed.return_value = feed_data
+
+    post_one = MockPost(guid="new-no-date-guid", release_date=None)
+    mock_make_post.return_value = post_one
+    mock_should_auto_whitelist.return_value = True
+
+    refresh_feed(mock_feed)
+
+    assert post_one.whitelisted is False
+    assert mock_should_auto_whitelist.call_count == 0
+    payload = mock_writer_client.action.call_args.args[1]
+    assert payload["new_posts"][0]["whitelisted"] is False
+
+
+@mock.patch("app.feeds.writer_client")
+@mock.patch("app.feeds._should_auto_whitelist_new_posts")
+@mock.patch("app.feeds.make_post")
+@mock.patch("app.feeds.fetch_feed")
 def test_refresh_feed_backfills_existing_unprocessed_post_duration(
     mock_fetch_feed,
     mock_make_post,


### PR DESCRIPTION
## Summary

- When a feed is refreshed, `refresh_feed` previously only compared new episodes against the oldest known post date. This allowed back-catalog episodes to be auto-whitelisted if they were newer than the very oldest post but older than any whitelisted episode.
- Now computes a `floor_date` as the stricter (more recent) of the oldest known post date and the oldest whitelisted post date. Episodes older than this floor or missing a `release_date` are never auto-whitelisted on refresh.
- Extracted the whitelisting decision into a `_should_whitelist_new_post` helper to keep `refresh_feed` within ruff's branch complexity limit.

**Relationship to PR #189**: PR #189 (merged) added a downstream guard in `_ensure_jobs_for_all_posts` to skip job creation for posts that already have processed audio. That prevents re-processing already-finished posts but does NOT prevent new back-catalog episodes from being whitelisted and queued in the first place. This PR fixes the root cause — preventing the auto-whitelisting of old episodes during feed refresh.

## Changes

- `src/app/feeds.py`: Added `_should_whitelist_new_post()` helper and `floor_date` calculation based on whitelisted post dates
- `src/tests/test_feeds.py`: 2 new tests — back-catalog episode blocked by whitelisted floor, and episode without release_date blocked

## Test plan

- [x] New episode older than the oldest whitelisted post is NOT auto-whitelisted
- [x] New episode without a release_date is NOT auto-whitelisted when a floor_date exists
- [x] Existing whitelist behavior preserved (existing tests pass: `unwhitelists_without_members`, `whitelists_when_member_exists`)
- [x] Full test suite passes (2 pre-existing flaky failures in `test_post_cleanup.py` unrelated — already fixed in PR #208)

🤖 Generated with [Claude Code](https://claude.ai/code)