### PR TITLE
fix: use dvh units to prevent bottom cutoff on Android Chrome

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,6 +6,7 @@ html, body {
 }
 
 #root {
+  height: 100vh !important;
   height: 100dvh !important;
   overflow: hidden !important;
   max-width: none !important;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,7 +6,7 @@ html, body {
 }
 
 #root {
-  height: 100vh !important;
+  height: 100dvh !important;
   overflow: hidden !important;
   max-width: none !important;
   margin: 0 !important;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,7 @@ function AppShell() {
 
   if (status === 'loading') {
     return (
-      <div className="h-screen flex items-center justify-center bg-gray-50">
+      <div className="h-dvh flex items-center justify-center bg-gray-50">
         <div className="flex flex-col items-center gap-4">
           <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
           <p className="text-sm text-gray-600">Loading authentication…</p>
@@ -98,7 +98,7 @@ function AppShell() {
   const showBillingLink = requireAuth && !isAdmin;
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
+    <div className="h-dvh bg-gray-50 flex flex-col overflow-hidden">
       <header className="bg-white shadow-sm border-b flex-shrink-0">
         <div className="px-2 sm:px-4 lg:px-6">
           <div className="flex items-center justify-between h-12">

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -15,7 +15,7 @@ export default function LandingPage() {
   const slotsRemaining = status?.slots_remaining;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white overflow-y-auto overflow-x-hidden fixed inset-0">
+    <div className="min-h-dvh bg-gradient-to-b from-gray-50 to-white overflow-y-auto overflow-x-hidden fixed inset-0">
       {/* Header */}
       <header className="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-md border-b border-gray-100 z-50">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -85,7 +85,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+    <div className="min-h-dvh bg-gray-50 flex items-center justify-center px-4">
       <div className="fixed right-4 top-4">
         <ThemeToggle />
       </div>


### PR DESCRIPTION
## Summary
- Replace `100vh` / `h-screen` / `min-h-screen` with `100dvh` / `h-dvh` / `min-h-dvh` across all layout containers
- On Chrome Android, `100vh` includes space behind the dynamic address/navigation bars, cutting off the bottom of every page
- `dvh` (dynamic viewport height) adjusts when browser chrome shows/hides, supported in all modern browsers (Chrome 108+, Safari 15.4+, Firefox 101+)
- Add `100vh` fallback before `100dvh` in `App.css` so older browsers that don't support `dvh` get the previous behavior instead of no height constraint

## Files changed
- `frontend/src/App.css` — `#root` height (with `100vh` fallback)
- `frontend/src/App.tsx` — main layout + loading state containers
- `frontend/src/pages/LandingPage.tsx` — landing page wrapper
- `frontend/src/pages/LoginPage.tsx` — login page wrapper

## Test plan
- [x] Test on Chrome Android — bottom of pages should be fully visible
- [x] Test pagination buttons (e.g. "Next" on feed episode list) are accessible
- [ ] Verify desktop browsers still render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)