### PR TITLE
perf(feed): short-circuit unchanged feeds with ETag/Last-Modified 304s

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -631,6 +631,44 @@ def feed_item(post: Post, prepend_feed_title: bool = False) -> PyRSS2Gen.RSSItem
     return item
 
 
+def _feed_last_changed_at_aware(feed: Feed) -> datetime.datetime:
+    """Return `feed.last_changed_at` as an aware UTC datetime.
+
+    `last_changed_at` is stored naive (UTC) to match other timestamps in
+    the schema; HTTP date / RFC 2822 formatters require an aware value.
+    Falls back to `now()` for legacy rows that may pre-date the column.
+    """
+    raw = getattr(feed, "last_changed_at", None)
+    if raw is None:
+        return datetime.datetime.now(datetime.UTC)
+    if raw.tzinfo is None:
+        return raw.replace(tzinfo=datetime.UTC)
+    return raw.astimezone(datetime.UTC)
+
+
+def get_aggregate_feed_last_changed_at(user: User | None) -> datetime.datetime:
+    """Return the max `last_changed_at` across feeds in this user's aggregate.
+
+    Used as the aggregate feed's `lastBuildDate` and for ETag freshness.
+    Falls back to `now()` when there are no feeds (or the configured user
+    has no subscriptions yet).
+    """
+    if not current_app.config.get("REQUIRE_AUTH") or user is None:
+        latest = db.session.query(db.func.max(Feed.last_changed_at)).scalar()
+    else:
+        latest = (
+            db.session.query(db.func.max(Feed.last_changed_at))
+            .join(UserFeed, UserFeed.feed_id == Feed.id)
+            .filter(UserFeed.user_id == user.id)
+            .scalar()
+        )
+    if latest is None:
+        return datetime.datetime.now(datetime.UTC)
+    if latest.tzinfo is None:
+        return latest.replace(tzinfo=datetime.UTC)
+    return latest.astimezone(datetime.UTC)
+
+
 def generate_feed_xml(feed: Feed) -> Any:
     logger.info(f"Generating XML for feed with ID: {feed.id}")
 
@@ -654,7 +692,7 @@ def generate_feed_xml(feed: Feed) -> Any:
     base_url = _get_base_url()
     link = _append_feed_token_params(f"{base_url}/feed/{feed.id}")
 
-    last_build_date = format_datetime(datetime.datetime.now(datetime.UTC))
+    last_build_date = format_datetime(_feed_last_changed_at_aware(feed))
 
     rss_feed = PyRSS2Gen.RSS2(
         title="[podly] " + feed.title,
@@ -684,7 +722,7 @@ def generate_aggregate_feed_xml(user: User | None) -> Any:
     base_url = _get_base_url()
     link = _append_feed_token_params(f"{base_url}/feed/user/{user_id}")
 
-    last_build_date = format_datetime(datetime.datetime.now(datetime.UTC))
+    last_build_date = format_datetime(get_aggregate_feed_last_changed_at(user))
 
     if current_app.config.get("REQUIRE_AUTH") and user:
         feed_title = f"Podly Podcasts - {user.username}"

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -48,6 +48,11 @@ class Feed(db.Model):  # type: ignore[name-defined, misc]
     # Per-feed override for LLM chapter fallback tagging, null = use global config
     enable_llm_chapter_fallback_tagging = db.Column(db.Boolean, nullable=True)
     auto_whitelist_new_episodes_override = db.Column(db.Boolean, nullable=True)
+    # Bumped by `refresh_feed_action` whenever something actually changes
+    # (new posts, post field updates, channel-level updates). Used as the
+    # `lastBuildDate` and as the input to the response ETag, so unchanged
+    # feeds can short-circuit reader polls with a 304.
+    last_changed_at = db.Column(db.DateTime, nullable=False, default=_utc_now_naive)
 
     posts = db.relationship(
         "Post", backref="feed", lazy=True, order_by="Post.release_date.desc()"

--- a/src/app/routes/feed_routes.py
+++ b/src/app/routes/feed_routes.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import logging
 import secrets
 from pathlib import Path
@@ -22,6 +23,7 @@ from flask import (
     url_for,
 )
 from flask.typing import ResponseReturnValue
+from werkzeug.http import http_date
 
 from app.auth import is_auth_enabled
 from app.auth.guards import require_admin
@@ -32,12 +34,14 @@ from app.feeds import (
     add_or_refresh_feed,
     generate_aggregate_feed_xml,
     generate_feed_xml,
+    get_aggregate_feed_last_changed_at,
     is_feed_active_for_user,
     refresh_feed,
 )
 from app.jobs_manager import get_jobs_manager
 from app.models import (
     Feed,
+    Post,
     User,
     UserFeed,
 )
@@ -342,6 +346,90 @@ def search_feeds() -> ResponseReturnValue:
     )
 
 
+def _aware_utc(value: datetime.datetime | None) -> datetime.datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.UTC)
+    return value.astimezone(datetime.UTC)
+
+
+def _compute_feed_etag(feed: Feed) -> str:
+    """Build a strong ETag value (bare hash, unquoted) for `feed`'s state.
+
+    Inputs are chosen so the tag changes whenever rendered XML can change:
+    `last_changed_at` covers post / channel updates; the post-count and max
+    post-id together catch row creations and (rare) row deletions even if
+    `last_changed_at` is briefly stale.
+    """
+    post_count, max_post_id = (
+        db.session.query(db.func.count(Post.id), db.func.max(Post.id))
+        .filter(Post.feed_id == feed.id)
+        .one()
+    )
+    last_changed = feed.last_changed_at or datetime.datetime.now(datetime.UTC)
+    payload = (
+        f"{feed.id}:{last_changed.isoformat()}:{post_count or 0}:{max_post_id or 0}"
+    )
+    return hashlib.sha1(payload.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def _compute_aggregate_etag(user: User | None) -> str:
+    """Build a strong ETag value (bare hash) for the aggregate feed.
+
+    Folds in the set of feed ids so subscribing/unsubscribing invalidates
+    cached responses on the next poll.
+    """
+    if not current_app.config.get("REQUIRE_AUTH") or user is None:
+        feed_ids = sorted(r[0] for r in db.session.query(Feed.id).all())
+    else:
+        feed_ids = sorted(
+            r[0]
+            for r in db.session.query(UserFeed.feed_id)
+            .filter(UserFeed.user_id == user.id)
+            .all()
+        )
+    last_changed = get_aggregate_feed_last_changed_at(user)
+    user_id = user.id if user else 0
+    payload = f"agg:{user_id}:{last_changed.isoformat()}:{','.join(map(str, feed_ids))}"
+    return hashlib.sha1(payload.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def _client_has_current_version(
+    etag: str, last_modified_aware: datetime.datetime | None
+) -> bool:
+    """True if the request signals it already has this exact response.
+
+    Honors `If-None-Match` (preferred) and `If-Modified-Since` (legacy).
+    `etag` is the bare digest (without surrounding quotes).
+    """
+    if request.if_none_match and request.if_none_match.contains(etag):
+        return True
+    if last_modified_aware is not None and request.if_modified_since is not None:
+        # HTTP dates are second-resolution; drop microseconds before comparing.
+        lm = last_modified_aware.replace(microsecond=0)
+        ims = request.if_modified_since
+        if ims.tzinfo is None:
+            ims = ims.replace(tzinfo=datetime.UTC)
+        if lm <= ims:
+            return True
+    return False
+
+
+def _apply_feed_response_headers(
+    response: Response, etag: str, last_modified_aware: datetime.datetime
+) -> None:
+    response.headers["ETag"] = f'"{etag}"'
+    response.headers["Last-Modified"] = http_date(last_modified_aware)
+    response.headers["Cache-Control"] = "public, max-age=60"
+
+
+def _make_feed_304(etag: str, last_modified_aware: datetime.datetime) -> Response:
+    response = make_response("", 304)
+    _apply_feed_response_headers(response, etag, last_modified_aware)
+    return response
+
+
 @feed_bp.route("/feed/<int:f_id>", methods=["GET"])
 def get_feed(f_id: int) -> Response:
     if hasattr(g, "current_user") and g.current_user:
@@ -349,14 +437,30 @@ def get_feed(f_id: int) -> Response:
 
     feed = Feed.query.get_or_404(f_id)
 
-    # Refresh the feed
+    # Fast path: if the reader already has the current version, return 304
+    # before doing any upstream fetch or XML build. Stays correct because the
+    # background scheduler is responsible for keeping `last_changed_at` fresh;
+    # readers just see the previous version one cycle longer when the
+    # scheduler hasn't run yet.
+    cached_etag = _compute_feed_etag(feed)
+    cached_last_modified = _aware_utc(feed.last_changed_at)
+    if cached_last_modified is not None and _client_has_current_version(
+        cached_etag, cached_last_modified
+    ):
+        return _make_feed_304(cached_etag, cached_last_modified)
+
     refresh_feed(feed)
 
-    # Generate the XML
+    fresh_etag = _compute_feed_etag(feed)
+    fresh_last_modified = _aware_utc(feed.last_changed_at) or datetime.datetime.now(
+        datetime.UTC
+    )
+
     xml_content = generate_feed_xml(feed)
 
     response = make_response(xml_content)
     response.headers["Content-Type"] = "application/rss+xml"
+    _apply_feed_response_headers(response, fresh_etag, fresh_last_modified)
     return response
 
 
@@ -697,18 +801,18 @@ def get_user_aggregate_feed(user_id: int) -> Response:
             return make_response(("Forbidden", 403))
 
     user = db.session.get(User, user_id)
-    if not user:
-        if user_id == 0 and not is_auth_enabled():
-            # Support anonymous aggregate feed when auth is disabled
-            xml_content = generate_aggregate_feed_xml(None)
-            response = make_response(xml_content)
-            response.headers["Content-Type"] = "application/rss+xml"
-            return response
+    if not user and not (user_id == 0 and not is_auth_enabled()):
         return make_response(("User not found", 404))
+
+    etag = _compute_aggregate_etag(user)
+    last_modified = get_aggregate_feed_last_changed_at(user)
+    if _client_has_current_version(etag, last_modified):
+        return _make_feed_304(etag, last_modified)
 
     xml_content = generate_aggregate_feed_xml(user)
     response = make_response(xml_content)
     response.headers["Content-Type"] = "application/rss+xml"
+    _apply_feed_response_headers(response, etag, last_modified)
     return response
 
 

--- a/src/app/writer/actions/feeds.py
+++ b/src/app/writer/actions/feeds.py
@@ -20,6 +20,30 @@ from app.models import (
 )
 
 
+def _apply_existing_post_updates(
+    feed: Feed, existing_post_updates: list[dict[str, Any]]
+) -> int:
+    updated_posts_count = 0
+    for post_update in existing_post_updates:
+        post_id = post_update.get("post_id")
+        if not post_id:
+            continue
+        post = db.session.get(Post, int(post_id))
+        if not post or post.feed_id != feed.id:
+            continue
+
+        updated = False
+        for field_name in ("title", "description", "image_url", "duration"):
+            if field_name not in post_update:
+                continue
+            setattr(post, field_name, post_update[field_name])
+            updated = True
+
+        if updated:
+            updated_posts_count += 1
+    return updated_posts_count
+
+
 def refresh_feed_action(params: dict[str, Any]) -> dict[str, Any]:
     feed_id = params.get("feed_id")
     updates = params.get("updates", {})
@@ -29,6 +53,8 @@ def refresh_feed_action(params: dict[str, Any]) -> dict[str, Any]:
     feed = db.session.get(Feed, feed_id)
     if not feed:
         raise ValueError(f"Feed {feed_id} not found")
+
+    feed_changed = bool(updates) or bool(new_posts_data)
 
     for k, v in updates.items():
         setattr(feed, k, v)
@@ -60,24 +86,10 @@ def refresh_feed_action(params: dict[str, Any]) -> dict[str, Any]:
             )
             db.session.add(job)
 
-    updated_posts_count = 0
-    for post_update in existing_post_updates:
-        post_id = post_update.get("post_id")
-        if not post_id:
-            continue
-        post = db.session.get(Post, int(post_id))
-        if not post or post.feed_id != feed.id:
-            continue
+    updated_posts_count = _apply_existing_post_updates(feed, existing_post_updates)
 
-        updated = False
-        for field_name in ("title", "description", "image_url", "duration"):
-            if field_name not in post_update:
-                continue
-            setattr(post, field_name, post_update[field_name])
-            updated = True
-
-        if updated:
-            updated_posts_count += 1
+    if feed_changed or updated_posts_count > 0:
+        feed.last_changed_at = datetime.now(UTC).replace(tzinfo=None)
 
     recalculate_run_counts(db.session)
 

--- a/src/migrations/versions/8a4d0c2f3e91_feed_last_changed_at.py
+++ b/src/migrations/versions/8a4d0c2f3e91_feed_last_changed_at.py
@@ -1,0 +1,43 @@
+"""feed last_changed_at
+
+Revision ID: 8a4d0c2f3e91
+Revises: 3e5eebc6b3b1
+Create Date: 2026-04-28 00:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8a4d0c2f3e91"
+down_revision = "3e5eebc6b3b1"
+branch_labels = None
+depends_on = None
+
+
+def column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(sa.text(f"PRAGMA table_info({table_name})"))
+    columns = [row[1] for row in result.fetchall()]
+    return column_name in columns
+
+
+def upgrade():
+    if column_exists("feed", "last_changed_at"):
+        return
+    with op.batch_alter_table("feed", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_changed_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.current_timestamp(),
+            )
+        )
+
+
+def downgrade():
+    if column_exists("feed", "last_changed_at"):
+        with op.batch_alter_table("feed", schema=None) as batch_op:
+            batch_op.drop_column("last_changed_at")

--- a/src/tests/test_feed_etag.py
+++ b/src/tests/test_feed_etag.py
@@ -1,0 +1,351 @@
+"""Tests for ETag / Last-Modified / 304 short-circuit on feed routes.
+
+These cover PR 2 of the feed performance audit. The aim is for podcast
+readers polling an unchanged feed to receive a fast 304 response that
+skips the upstream fetch and the XML rebuild entirely.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest import mock
+
+from werkzeug.http import http_date
+
+from app.extensions import db
+from app.feeds import generate_feed_xml
+from app.models import Feed, Post
+from app.routes.feed_routes import feed_bp
+from app.writer.actions.feeds import refresh_feed_action
+
+
+def _make_feed_with_post(rss_url: str = "https://example.com/feed.xml") -> int:
+    feed = Feed(title="Etag Feed", rss_url=rss_url)
+    db.session.add(feed)
+    db.session.commit()
+
+    post = Post(
+        feed_id=feed.id,
+        guid=f"post-guid-{feed.id}",
+        download_url=f"{rss_url}/ep1.mp3",
+        title="Episode 1",
+        release_date=dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC),
+    )
+    db.session.add(post)
+    db.session.commit()
+    return feed.id
+
+
+def test_feed_has_default_last_changed_at(app):
+    with app.app_context():
+        feed = Feed(title="Feed A", rss_url="https://example.com/a.xml")
+        db.session.add(feed)
+        db.session.commit()
+        db.session.refresh(feed)
+        assert feed.last_changed_at is not None
+        assert isinstance(feed.last_changed_at, dt.datetime)
+
+
+def test_refresh_feed_action_bumps_last_changed_at_on_new_post(app):
+    with app.app_context():
+        feed = Feed(title="Feed B", rss_url="https://example.com/b.xml")
+        db.session.add(feed)
+        db.session.commit()
+        original_changed = feed.last_changed_at
+        # ensure the bump produces a strictly later timestamp
+        feed.last_changed_at = original_changed - dt.timedelta(hours=1)
+        db.session.commit()
+        old_changed = feed.last_changed_at
+
+        refresh_feed_action(
+            {
+                "feed_id": feed.id,
+                "new_posts": [
+                    {
+                        "guid": "new-guid",
+                        "title": "New Ep",
+                        "description": "",
+                        "download_url": "https://example.com/b/new.mp3",
+                        "release_date": "2026-04-01T12:00:00+00:00",
+                        "duration": 60,
+                        "image_url": None,
+                        "whitelisted": False,
+                        "feed_id": feed.id,
+                    }
+                ],
+            }
+        )
+        db.session.commit()
+        db.session.refresh(feed)
+        assert feed.last_changed_at is not None
+        assert feed.last_changed_at > old_changed
+
+
+def test_refresh_feed_action_bumps_last_changed_at_on_existing_post_update(app):
+    with app.app_context():
+        feed = Feed(title="Feed C", rss_url="https://example.com/c.xml")
+        db.session.add(feed)
+        db.session.commit()
+        post = Post(
+            feed_id=feed.id,
+            guid="g-c",
+            download_url="https://example.com/c/ep.mp3",
+            title="Old title",
+        )
+        db.session.add(post)
+        db.session.commit()
+        feed.last_changed_at = feed.last_changed_at - dt.timedelta(hours=1)
+        db.session.commit()
+        old_changed = feed.last_changed_at
+
+        refresh_feed_action(
+            {
+                "feed_id": feed.id,
+                "existing_post_updates": [
+                    {"post_id": post.id, "title": "Newer title"},
+                ],
+            }
+        )
+        db.session.commit()
+        db.session.refresh(feed)
+        assert feed.last_changed_at > old_changed
+
+
+def test_refresh_feed_action_does_not_bump_when_nothing_changes(app):
+    with app.app_context():
+        feed = Feed(title="Feed D", rss_url="https://example.com/d.xml")
+        db.session.add(feed)
+        db.session.commit()
+        old_changed = feed.last_changed_at
+
+        refresh_feed_action({"feed_id": feed.id})
+        db.session.commit()
+        db.session.refresh(feed)
+        assert feed.last_changed_at == old_changed
+
+
+def test_generate_feed_xml_uses_feed_last_changed_at(app):
+    """`lastBuildDate` must come from `Feed.last_changed_at`, not now()."""
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+        feed = db.session.get(Feed, feed_id)
+        fixed = dt.datetime(2025, 6, 15, 10, 30, 0)
+        feed.last_changed_at = fixed
+        db.session.commit()
+
+        with mock.patch("app.feeds._get_base_url", return_value="http://test"):
+            xml_bytes = generate_feed_xml(feed)
+        xml = xml_bytes.decode("utf-8") if isinstance(xml_bytes, bytes) else xml_bytes
+        # RSS pubDate / lastBuildDate format: e.g., "Sun, 15 Jun 2025 10:30:00 +0000"
+        assert "15 Jun 2025 10:30:00" in xml
+
+
+def _register_feed_routes(app) -> None:
+    if "feed" not in app.blueprints:
+        app.register_blueprint(feed_bp)
+
+
+def test_get_feed_emits_etag_and_last_modified_headers(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed"),
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        resp = client.get(f"/feed/{feed_id}")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("ETag")
+    assert resp.headers.get("Last-Modified")
+
+
+def test_get_feed_returns_304_when_etag_matches(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed") as mock_refresh,
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        first = client.get(f"/feed/{feed_id}")
+        etag = first.headers["ETag"]
+
+        second = client.get(f"/feed/{feed_id}", headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    # the body of a 304 must be empty
+    assert second.get_data(as_text=True) == ""
+    # ETag header is required on a 304 per RFC 9110
+    assert second.headers.get("ETag") == etag
+    # the second call must NOT have triggered a refresh — that's the entire point.
+    assert mock_refresh.call_count == 1  # only the first call refreshed
+
+
+def test_get_feed_skips_refresh_and_xml_when_etag_matches(app):
+    """The 304 path is the latency win: refresh and XML build must be skipped."""
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+        feed = db.session.get(Feed, feed_id)
+        # We need a stable ETag value to check on the FIRST request,
+        # so seed last_changed_at to a known value.
+        feed.last_changed_at = dt.datetime(2026, 1, 1, 0, 0, 0)
+        db.session.commit()
+
+    client = app.test_client()
+    # First, get the canonical ETag the route would produce.
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed"),
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        bootstrap = client.get(f"/feed/{feed_id}")
+    etag = bootstrap.headers["ETag"]
+
+    # Now make a fresh request with If-None-Match. Both refresh and XML should
+    # be untouched — that's the latency win.
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed") as mock_refresh,
+        mock.patch("app.routes.feed_routes.generate_feed_xml") as mock_gen,
+    ):
+        resp = client.get(f"/feed/{feed_id}", headers={"If-None-Match": etag})
+
+    assert resp.status_code == 304
+    mock_refresh.assert_not_called()
+    mock_gen.assert_not_called()
+
+
+def test_get_feed_returns_200_when_etag_does_not_match(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed"),
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        resp = client.get(
+            f"/feed/{feed_id}", headers={"If-None-Match": '"obviously-stale"'}
+        )
+
+    assert resp.status_code == 200
+    assert resp.data == b"<rss/>"
+
+
+def test_get_feed_returns_304_when_if_modified_since_recent(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+        feed = db.session.get(Feed, feed_id)
+        feed.last_changed_at = dt.datetime(2026, 1, 1, 0, 0, 0)
+        db.session.commit()
+
+    client = app.test_client()
+    # Client claims it last fetched 1 hour AFTER our last_changed_at — so 304.
+    later = dt.datetime(2026, 1, 1, 1, 0, 0, tzinfo=dt.UTC)
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed") as mock_refresh,
+        mock.patch("app.routes.feed_routes.generate_feed_xml") as mock_gen,
+    ):
+        resp = client.get(
+            f"/feed/{feed_id}", headers={"If-Modified-Since": http_date(later)}
+        )
+
+    assert resp.status_code == 304
+    mock_refresh.assert_not_called()
+    mock_gen.assert_not_called()
+
+
+def test_get_feed_etag_changes_when_last_changed_at_changes(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+        feed = db.session.get(Feed, feed_id)
+        feed.last_changed_at = dt.datetime(2026, 1, 1, 0, 0, 0)
+        db.session.commit()
+    # In real deployments the writer runs in a separate process so the request
+    # session never sees a stale identity-map entry. The pytest fixture wraps
+    # everything in a single app context (and therefore a single shared
+    # session), so we expire it explicitly to mirror that behavior.
+    db.session.expire_all()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed"),
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        first = client.get(f"/feed/{feed_id}")
+    first_etag = first.headers["ETag"]
+
+    with app.app_context():
+        feed = db.session.get(Feed, feed_id)
+        feed.last_changed_at = dt.datetime(2026, 1, 2, 0, 0, 0)
+        db.session.commit()
+    db.session.expire_all()
+
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed"),
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+    ):
+        second = client.get(f"/feed/{feed_id}")
+
+    assert second.headers["ETag"] != first_etag
+
+
+def test_get_user_aggregate_feed_emits_etag(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        app.config["REQUIRE_AUTH"] = False
+        _make_feed_with_post("https://example.com/agg-1.xml")
+        _make_feed_with_post("https://example.com/agg-2.xml")
+
+    client = app.test_client()
+    with mock.patch(
+        "app.routes.feed_routes.generate_aggregate_feed_xml", return_value=b"<rss/>"
+    ):
+        resp = client.get("/feed/user/0")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("ETag")
+    assert resp.headers.get("Last-Modified")
+
+
+def test_get_user_aggregate_feed_returns_304_when_etag_matches(app):
+    app.testing = True
+    _register_feed_routes(app)
+
+    with app.app_context():
+        app.config["REQUIRE_AUTH"] = False
+        _make_feed_with_post("https://example.com/agg-3.xml")
+        _make_feed_with_post("https://example.com/agg-4.xml")
+
+    client = app.test_client()
+    with mock.patch(
+        "app.routes.feed_routes.generate_aggregate_feed_xml", return_value=b"<rss/>"
+    ) as mock_gen:
+        first = client.get("/feed/user/0")
+        etag = first.headers["ETag"]
+        second = client.get("/feed/user/0", headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    # XML must not be regenerated on the 304 path
+    assert mock_gen.call_count == 1

--- a/src/tests/test_feeds.py
+++ b/src/tests/test_feeds.py
@@ -1238,9 +1238,7 @@ def test_get_guid_falls_back_to_url_hash_when_id_missing(mock_find_audio_link):
     mock_find_audio_link.return_value = "https://cdn.example.com/audio.mp3"
     entry = SimpleNamespace()  # no id, no guid
 
-    expected = str(
-        uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3")
-    )
+    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3"))
     assert get_guid(entry) == expected
 
 
@@ -1250,9 +1248,7 @@ def test_get_guid_falls_back_to_url_hash_when_id_empty(mock_find_audio_link):
     mock_find_audio_link.return_value = "https://cdn.example.com/audio.mp3"
     entry = SimpleNamespace(id="", guid=None)
 
-    expected = str(
-        uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3")
-    )
+    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3"))
     assert get_guid(entry) == expected
 
 
@@ -1262,9 +1258,7 @@ def test_get_guid_falls_back_to_url_hash_when_id_whitespace_only(mock_find_audio
     mock_find_audio_link.return_value = "https://cdn.example.com/audio.mp3"
     entry = SimpleNamespace(id="   \n  ", guid=None)
 
-    expected = str(
-        uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3")
-    )
+    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "https://cdn.example.com/audio.mp3"))
     assert get_guid(entry) == expected
 
 


### PR DESCRIPTION
## Summary

Feed routes used to do a full upstream refresh and rebuild the RSS XML on every poll, even when nothing had changed. Podcast clients poll constantly, so the bulk of that work was wasted.

This adds a `Feed.last_changed_at` column that the writer bumps only when something actually changes (channel updates, new posts, edited posts). The feed routes use it to:

- emit `ETag` (sha1 of feed id, `last_changed_at`, post count, max post id), `Last-Modified`, and `Cache-Control: public, max-age=60`
- honor `If-None-Match` and `If-Modified-Since` and return `304 Not Modified` **before** touching the upstream fetch or the XML build
- drive `lastBuildDate` from the same field instead of `now()`

The aggregate feed route gets the same treatment, with the ETag also folding in the set of feed ids so subscribe/unsubscribe invalidates the cache.

Idle reader polls now return `O(bytes-of-headers)` and skip the most expensive work in the request path.

## Files

- `src/app/models.py` — new `Feed.last_changed_at` column
- `src/migrations/versions/8a4d0c2f3e91_feed_last_changed_at.py` — Alembic migration (idempotent)
- `src/app/writer/actions/feeds.py` — bump `last_changed_at` only on real changes
- `src/app/feeds.py` — `lastBuildDate` from `last_changed_at`; aggregate helper
- `src/app/routes/feed_routes.py` — ETag/Last-Modified/304 short-circuit on `/feed/<id>` and `/feed/user/<id>`
- `src/tests/test_feed_etag.py` — 13 new tests

## Test plan

- [x] `uv run pytest src/tests/test_feed_etag.py` — 13 tests pass
- [x] `uv run pytest src/tests/` — full suite green (297 passed, 3 skipped)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format` — clean
- [ ] Verify on a real client (Overcast / Pocket Casts) that subsequent polls hit 304 once cached

## Notes

This is PR 2 of the feed performance audit (after #216, the GUID fix). Single-feed and aggregate routes both honor conditional requests; the ETag formula is robust against post deletions even if `last_changed_at` is briefly stale.

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)