### PR TITLE
perf(feed): drop synchronous refresh_feed from GET /feed/<id>

### DIFF
--- a/src/app/routes/feed_routes.py
+++ b/src/app/routes/feed_routes.py
@@ -1,8 +1,9 @@
 import datetime
 import logging
 import secrets
+import time
 from pathlib import Path
-from threading import Thread
+from threading import Lock, Thread
 from typing import Any, cast
 from urllib.parse import urlencode
 
@@ -59,6 +60,16 @@ logger = logging.getLogger("global_logger")
 
 feed_bp = Blueprint("feed", __name__)
 _MISSING = object()
+
+# Per-feed debounce so that bursty reader polls don't fan out into N background
+# refresh threads. The scheduled `refresh_all_feeds` job
+# (`src/app/background.py`) is the primary freshness mechanism; this just
+# opportunistically nudges a single-feed refresh on read traffic without ever
+# blocking the response. In-memory state is fine: a process restart simply
+# resets the cooldown and the next poll triggers a fresh kickoff.
+_BACKGROUND_REFRESH_LOCK = Lock()
+_BACKGROUND_REFRESH_LAST_KICKOFF: dict[int, float] = {}
+_AUTO_REFRESH_COOLDOWN_SECONDS = 60.0
 
 
 def _parse_optional_feed_bool(
@@ -342,6 +353,26 @@ def search_feeds() -> ResponseReturnValue:
     )
 
 
+def _should_kickoff_async_refresh(feed_id: int) -> bool:
+    """True iff the per-feed cooldown has elapsed; reserves the next slot."""
+    now = time.monotonic()
+    with _BACKGROUND_REFRESH_LOCK:
+        last = _BACKGROUND_REFRESH_LAST_KICKOFF.get(feed_id)
+        if last is not None and now - last < _AUTO_REFRESH_COOLDOWN_SECONDS:
+            return False
+        _BACKGROUND_REFRESH_LAST_KICKOFF[feed_id] = now
+        return True
+
+
+def _spawn_async_refresh(app: Flask, feed_id: int) -> None:
+    Thread(
+        target=_refresh_feed_background,
+        args=(app, feed_id),
+        daemon=True,
+        name=f"feed-auto-refresh-{feed_id}",
+    ).start()
+
+
 @feed_bp.route("/feed/<int:f_id>", methods=["GET"])
 def get_feed(f_id: int) -> Response:
     if hasattr(g, "current_user") and g.current_user:
@@ -349,10 +380,14 @@ def get_feed(f_id: int) -> Response:
 
     feed = Feed.query.get_or_404(f_id)
 
-    # Refresh the feed
-    refresh_feed(feed)
+    # Don't block the response on an upstream RSS fetch. The scheduled
+    # `refresh_all_feeds` job is the primary freshness source; we additionally
+    # nudge a per-feed refresh on read traffic, debounced so bursty pollers
+    # don't fan out into N threads.
+    if _should_kickoff_async_refresh(f_id):
+        app = cast(Any, current_app)._get_current_object()
+        _spawn_async_refresh(app, f_id)
 
-    # Generate the XML
     xml_content = generate_feed_xml(feed)
 
     response = make_response(xml_content)

--- a/src/tests/test_get_feed_async_refresh.py
+++ b/src/tests/test_get_feed_async_refresh.py
@@ -1,0 +1,186 @@
+"""Tests for PR 3: `GET /feed/<id>` no longer blocks on `refresh_feed`.
+
+The route used to issue a synchronous upstream RSS fetch on every reader
+poll, which made feed-fetch latency upstream-bounded. PR 3 drops that
+synchronous call and instead kicks off a debounced refresh on a background
+thread (when not already kicked off recently). The scheduled
+`refresh_all_feeds` job remains the primary freshness source.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest import mock
+
+from app.extensions import db
+from app.models import Feed, Post
+from app.routes import feed_routes
+from app.routes.feed_routes import feed_bp
+
+
+def _make_feed_with_post(rss_url: str = "https://example.com/feed.xml") -> int:
+    feed = Feed(title="PR3 Feed", rss_url=rss_url)
+    db.session.add(feed)
+    db.session.commit()
+
+    post = Post(
+        feed_id=feed.id,
+        guid=f"post-guid-{feed.id}",
+        download_url=f"{rss_url}/ep1.mp3",
+        title="Episode 1",
+        release_date=dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC),
+    )
+    db.session.add(post)
+    db.session.commit()
+    return feed.id
+
+
+def _register_feed_routes(app) -> None:
+    if "feed" not in app.blueprints:
+        app.register_blueprint(feed_bp)
+
+
+def _reset_kickoff_state() -> None:
+    with feed_routes._BACKGROUND_REFRESH_LOCK:
+        feed_routes._BACKGROUND_REFRESH_LAST_KICKOFF.clear()
+
+
+def test_get_feed_does_not_call_refresh_feed_synchronously(app):
+    """The hot path on the request thread must not block on upstream fetch."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.refresh_feed") as mock_refresh,
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh"),
+    ):
+        resp = client.get(f"/feed/{feed_id}")
+
+    assert resp.status_code == 200
+    mock_refresh.assert_not_called()
+
+
+def test_get_feed_kicks_off_async_refresh(app):
+    """First poll for a feed should schedule a background refresh."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh") as mock_spawn,
+    ):
+        resp = client.get(f"/feed/{feed_id}")
+
+    assert resp.status_code == 200
+    mock_spawn.assert_called_once()
+    args, _ = mock_spawn.call_args
+    # second positional arg is the feed id
+    assert args[1] == feed_id
+
+
+def test_get_feed_debounces_repeated_polls(app):
+    """Quick repeat polls within the cooldown must not re-spawn refreshes."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh") as mock_spawn,
+    ):
+        client.get(f"/feed/{feed_id}")
+        client.get(f"/feed/{feed_id}")
+        client.get(f"/feed/{feed_id}")
+
+    assert mock_spawn.call_count == 1
+
+
+def test_get_feed_kickoff_resumes_after_cooldown(app):
+    """After the cooldown elapses, a fresh poll should kick off again."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    base = 1000.0
+    times = iter([base, base + 1.0, base + 1000.0])
+
+    with (
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh") as mock_spawn,
+        mock.patch(
+            "app.routes.feed_routes.time.monotonic", side_effect=lambda: next(times)
+        ),
+    ):
+        client.get(f"/feed/{feed_id}")  # base: kickoff
+        client.get(f"/feed/{feed_id}")  # base + 1s: debounced
+        client.get(f"/feed/{feed_id}")  # base + 1000s: kickoff again
+
+    assert mock_spawn.call_count == 2
+
+
+def test_get_feed_kickoff_independent_per_feed(app):
+    """Different feeds have independent cooldown windows."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_a = _make_feed_with_post("https://example.com/a.xml")
+        feed_b = _make_feed_with_post("https://example.com/b.xml")
+
+    client = app.test_client()
+    with (
+        mock.patch("app.routes.feed_routes.generate_feed_xml", return_value=b"<rss/>"),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh") as mock_spawn,
+    ):
+        client.get(f"/feed/{feed_a}")
+        client.get(f"/feed/{feed_b}")
+        client.get(f"/feed/{feed_a}")  # within cooldown — debounced
+
+    assert mock_spawn.call_count == 2
+    feed_ids = [call.args[1] for call in mock_spawn.call_args_list]
+    assert feed_ids == [feed_a, feed_b]
+
+
+def test_get_feed_returns_xml_when_kickoff_skipped(app):
+    """Even when the refresh is debounced, the response must still serve XML."""
+    app.testing = True
+    _register_feed_routes(app)
+    _reset_kickoff_state()
+
+    with app.app_context():
+        feed_id = _make_feed_with_post()
+
+    client = app.test_client()
+    with (
+        mock.patch(
+            "app.routes.feed_routes.generate_feed_xml",
+            return_value=b"<rss/>cached</rss/>",
+        ),
+        mock.patch("app.routes.feed_routes._spawn_async_refresh"),
+    ):
+        first = client.get(f"/feed/{feed_id}")
+        second = client.get(f"/feed/{feed_id}")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.data == b"<rss/>cached</rss/>"


### PR DESCRIPTION
## Problem

`GET /feed/<id>` is what podcast clients (Apple Podcasts, Overcast, AntennaPod, Pocket Casts, etc.) hit on every poll — every few minutes, per subscriber, per feed. Today the route handler does this on the request thread:

1. Load the feed from the DB.
2. Call `refresh_feed(feed)`, which calls `feedparser.parse(upstream_url)` — a **synchronous HTTP GET to the upstream publisher** + full RSS parse.
3. Build the XML and return it.

Step 2 is the killer. Every reader poll is bounded by however long the upstream publisher's CDN takes to respond — easily hundreds of milliseconds, sometimes several seconds. For an idle feed where nothing has changed, this work is pure overhead. And it scales badly: bursty fan-out from multi-feed pollers makes it worse.

The system already has a background scheduler (`scheduled_refresh_all_feeds`, default every 10 min) that does exactly this refresh. The per-request copy was largely duplicate work that pinned `/feed/<id>` latency to whatever the slowest upstream was doing today.

## What this PR does

**Removes the synchronous `refresh_feed(feed)` call from `get_feed`.** The response no longer waits on the network at all — it's now just a DB read + XML build.

To keep freshness from regressing on top of the scheduler's cadence, the route also **opportunistically kicks off a background refresh on a daemon thread**, with a per-feed 60-second debounce. Bursty polls don't fan out into N concurrent refresh threads; the first poll in a cooldown window schedules one refresh, the rest are silently no-ops. The kickoff never blocks the response.

The freshness guarantee is now: a feed is at most `max(scheduler_interval, cooldown)` stale, instead of being refreshed on every single poll at the cost of upstream-bounded request latency.

## Why no `?refresh=1` opt-in

I considered keeping a synchronous opt-in for the manual "refresh feed" button in the UI, but that button already hits the dedicated `POST /api/feeds/<id>/refresh` endpoint (which itself spawns a background thread and returns 202 Accepted). The GET path doesn't need a synchronous escape hatch — smaller diff wins.

## Files changed

- `src/app/routes/feed_routes.py` — drop synchronous refresh, add `_should_kickoff_async_refresh` (per-feed cooldown gate) and `_spawn_async_refresh` (thread launcher).
- `src/tests/test_get_feed_async_refresh.py` — new test file.

## Test plan

- [x] `uv run pytest src/tests/` — 290 passed, 3 skipped, full suite green.
- [x] `uv run ruff check src/` — clean.
- [x] `uv run ruff format --check src/` — clean.
- [x] New tests cover:
  - `refresh_feed` is **not** called from the request thread.
  - First poll for a feed schedules exactly one background refresh.
  - Repeat polls within the 60s cooldown are debounced (one kickoff, not three).
  - After the cooldown elapses, a fresh poll kicks off again.
  - Cooldowns are tracked per-feed (one feed's kickoff doesn't suppress another's).
  - Response still returns valid RSS XML when the kickoff is debounced.

## Performance impact

Before: idle `/feed/<id>` poll = TCP+TLS + upstream RTT (variable, network-bound) + RSS parse + DB load + XML render + transfer.

After: idle `/feed/<id>` poll = TCP+TLS + DB load + XML render + transfer. No upstream fetch on the request thread. A background refresh may run concurrently on the first poll within each cooldown window, but the client doesn't wait for it.

This stacks with PR #217 (ETag/Last-Modified/304 short-circuit, currently in review): with both landed, an unchanged feed serves a 304 with no DB-of-posts load, no XML build, no upstream fetch — `O(headers)` bytes total.

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)