### PR TITLE
fix(audio): drop ad audio entirely, fade surrounding content

### DIFF
--- a/src/podcast_processor/audio.py
+++ b/src/podcast_processor/audio.py
@@ -65,36 +65,42 @@ def _clip_segments_complex(
     out_path: str,
     audio_duration_ms: int,
 ) -> None:
-    """Original complex approach with fades."""
+    """Filter-graph approach: drop ad spans entirely and apply fades to the
+    surrounding content (fade-out at the tail of content before an ad,
+    fade-in at the head of content after an ad). The ad audio itself is
+    never kept.
+    """
 
-    trimmed_list = []
-
+    keep_segments: List[Tuple[int, int, bool, bool]] = []
     last_end = 0
     for start_ms, end_ms in ad_segments_ms:
-        trimmed_list.extend(
-            [
-                ffmpeg.input(in_path).filter(
-                    "atrim", start=last_end / 1000.0, end=start_ms / 1000.0
-                ),
-                ffmpeg.input(in_path)
-                .filter(
-                    "atrim", start=start_ms / 1000.0, end=(start_ms + fade_ms) / 1000.0
-                )
-                .filter("afade", t="out", ss=0, d=fade_ms / 1000.0),
-                ffmpeg.input(in_path)
-                .filter("atrim", start=(end_ms - fade_ms) / 1000.0, end=end_ms / 1000.0)
-                .filter("afade", t="in", ss=0, d=fade_ms / 1000.0),
-            ]
-        )
-
+        if start_ms > last_end:
+            keep_segments.append((last_end, start_ms, last_end > 0, True))
         last_end = end_ms
 
-    if last_end != audio_duration_ms:
-        trimmed_list.append(
-            ffmpeg.input(in_path).filter(
-                "atrim", start=last_end / 1000.0, end=audio_duration_ms / 1000.0
-            )
+    if last_end < audio_duration_ms:
+        keep_segments.append((last_end, audio_duration_ms, last_end > 0, False))
+
+    if not keep_segments:
+        raise ValueError("No audio segments to keep after ad removal")
+
+    fade_sec = fade_ms / 1000.0
+    trimmed_list = []
+    for start_ms, end_ms, fade_in, fade_out in keep_segments:
+        seg_dur_sec = (end_ms - start_ms) / 1000.0
+        eff_fade = min(fade_sec, seg_dur_sec / 2.0)
+        chain = (
+            ffmpeg.input(in_path)
+            .filter("atrim", start=start_ms / 1000.0, end=end_ms / 1000.0)
+            .filter("asetpts", "PTS-STARTPTS")
         )
+        if fade_in and eff_fade > 0:
+            chain = chain.filter("afade", t="in", st=0, d=eff_fade)
+        if fade_out and eff_fade > 0:
+            chain = chain.filter(
+                "afade", t="out", st=seg_dur_sec - eff_fade, d=eff_fade
+            )
+        trimmed_list.append(chain)
 
     logger.info(
         "[FFMPEG_CONCAT] Starting audio concatenation: %s -> %s (%d segments)",

--- a/src/tests/test_process_audio.py
+++ b/src/tests/test_process_audio.py
@@ -30,8 +30,7 @@ def test_clip_segment_with_fade() -> None:
         expected_duration = (
             TEST_FILE_DURATION
             - (ad_end_offset_ms - ad_start_offset_ms)
-            + 2 * fade_len_ms
-            + 56  # not sure where this fudge comes from
+            + 56  # mp3 frame-alignment fudge
         )
         actual_duration = get_audio_duration_ms(temp_file.name)
         assert actual_duration is not None, "Failed to get audio duration"
@@ -56,8 +55,7 @@ def test_clip_segment_with_fade_beginning() -> None:
         expected_duration = (
             TEST_FILE_DURATION
             - (ad_end_offset_ms - ad_start_offset_ms)
-            + 2 * fade_len_ms
-            + 56  # not sure where this fudge comes from
+            + 56  # mp3 frame-alignment fudge
         )
         actual_duration = get_audio_duration_ms(temp_file.name)
         assert actual_duration is not None, "Failed to get audio duration"
@@ -85,8 +83,7 @@ def test_clip_segment_with_fade_end() -> None:
         expected_duration = (
             TEST_FILE_DURATION
             - (ad_end_offset_ms - ad_start_offset_ms)
-            + 2 * fade_len_ms
-            + 56  # not sure where this fudge comes from
+            + 56  # mp3 frame-alignment fudge
         )
         actual_duration = get_audio_duration_ms(temp_file.name)
         assert actual_duration is not None, "Failed to get audio duration"


### PR DESCRIPTION
## Problem

`_clip_segments_complex` in `src/podcast_processor/audio.py` retains the first
and last `fade_ms` of every ad span, applying afade-out and afade-in to those
in-ad slices. With the default `fade_ms=3000`, every cut leaks ~6 s of audible
ad audio (3 s fading out at the start of the cut, 3 s fading in at the end).

The existing test `test_clip_segment_with_fade` encoded that behaviour with
`expected_duration += 2 * fade_len_ms`, which made the buggy code pass tests
even though listeners hear ads at every cut boundary.

I diagnosed this on a live deployment by transcribing the first 30 s of a
processed episode via Whisper. Got *This is your business. This is your business.
At sea. Why cruise when you can Cunard?* (Xero ad fading out, then Cunard ad
fading in) instead of the expected podcast intro. The cut list in
`post.refined_ad_boundaries` was correct (`[0.0–59.3]` was in it); only the
ffmpeg layer was wrong.

## Fix

Rewrite `_clip_segments_complex` to take the simple-path shape: build keep
segments between ads, drop the ad spans entirely, then apply afade-in to the
head and afade-out to the tail of each keep segment when there is an ad on
that side. `asetpts=PTS-STARTPTS` normalises timestamps so afade `st=` is
segment-relative. Effective fade duration is capped at half the segment length
so fade-in/out can never overlap on a short content gap.

Update `test_process_audio.py` expectations: removed `+ 2 * fade_len_ms` from
the three duration calculations. The `+56` mp3 frame-alignment fudge stays.

## Verification

- 10/10 tests pass (`test_process_audio.py` + `test_audio_processor.py`).
- `black`, `isort`, `mypy`, `pylint` clean on both files.
- Deployed against a live podcast and re-transcribed the first 30 s of the new
  processed file: now reads clean podcast intro audio with no ad text.