### PR TITLE
Add per-feed Whisper language override

### DIFF
--- a/frontend/src/components/AddFeedForm.tsx
+++ b/frontend/src/components/AddFeedForm.tsx
@@ -3,6 +3,7 @@ import { feedsApi } from '../services/api';
 import type { PodcastSearchResult } from '../types';
 import { diagnostics, emitDiagnosticError } from '../utils/diagnostics';
 import { getHttpErrorInfo } from '../utils/httpError';
+import { WHISPER_LANGUAGES } from '../constants/whisperLanguages';
 
 interface AddFeedFormProps {
   onSuccess: () => void;
@@ -16,6 +17,7 @@ const PAGE_SIZE = 10;
 
 export default function AddFeedForm({ onSuccess, onUpgradePlan, planLimitReached }: AddFeedFormProps) {
   const [url, setUrl] = useState('');
+  const [language, setLanguage] = useState('');
   const [activeMode, setActiveMode] = useState<AddMode>('search');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -58,11 +60,12 @@ export default function AddFeedForm({ onSuccess, onUpgradePlan, planLimitReached
     setUpgradePrompt(null);
 
     try {
-      diagnostics.add('info', 'Add feed request', { source, hasUrl: !!feedUrl });
-      await feedsApi.addFeed(feedUrl);
+      diagnostics.add('info', 'Add feed request', { source, hasUrl: !!feedUrl, hasLanguage: !!language });
+      await feedsApi.addFeed(feedUrl, language || null);
       if (source === 'url') {
         setUrl('');
       }
+      setLanguage('');
       diagnostics.add('info', 'Add feed success', { source });
       onSuccess();
     } catch (err) {
@@ -201,6 +204,29 @@ export default function AddFeedForm({ onSuccess, onUpgradePlan, planLimitReached
         >
           Search Podcasts
         </button>
+      </div>
+
+      <div className="mb-4">
+        <label htmlFor="new-feed-language" className="block text-sm font-medium text-gray-700 mb-1">
+          Transcription language (optional)
+        </label>
+        <p className="text-xs text-gray-500 mb-1">
+          Applies to whichever feed you add below.
+        </p>
+        <select
+          id="new-feed-language"
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          disabled={!!planLimitReached}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        >
+          <option value="">Use global setting</option>
+          {WHISPER_LANGUAGES.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.name}
+            </option>
+          ))}
+        </select>
       </div>
 
       {activeMode === 'url' && (

--- a/frontend/src/components/FeedDetail.tsx
+++ b/frontend/src/components/FeedDetail.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { copyToClipboard } from '../utils/clipboard';
 import { emitDiagnosticError } from '../utils/diagnostics';
 import { getHttpErrorInfo } from '../utils/httpError';
+import { WHISPER_LANGUAGES } from '../constants/whisperLanguages';
 
 interface FeedDetailProps {
   feed: Feed;
@@ -127,7 +128,35 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
         auto_whitelist_new_episodes_override: override,
       }),
     onSuccess: (data) => {
-      setCurrentFeed(data);
+      setCurrentFeed((cur) => (cur.id === data.id ? data : cur));
+      queryClient.invalidateQueries({ queryKey: ['feeds'] });
+      toast.success('Feed settings updated');
+    },
+    onError: (err) => {
+      const { status, data, message } = getHttpErrorInfo(err);
+      emitDiagnosticError({
+        title: 'Failed to update feed settings',
+        message,
+        kind: status ? 'http' : 'network',
+        details: {
+          status,
+          response: data,
+          feedId: currentFeed.id,
+        },
+      });
+      toast.error('Failed to update feed settings');
+    },
+  });
+
+  const updateLanguageMutation = useMutation({
+    mutationFn: (language: string | null) =>
+      feedsApi.updateFeedSettings(currentFeed.id, { language }),
+    onSuccess: (data) => {
+      // Apply the server's returned feed locally — HomePage holds
+      // `selectedFeed` as a snapshot, so without this write the
+      // dropdown stays on the old value. Guarded against the user
+      // having switched feeds before the PATCH resolved.
+      setCurrentFeed((cur) => (cur.id === data.id ? data : cur));
       queryClient.invalidateQueries({ queryKey: ['feeds'] });
       toast.success('Feed settings updated');
     },
@@ -325,6 +354,10 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
     const override =
       value === 'inherit' ? null : value === 'on';
     updateFeedSettingsMutation.mutate(override);
+  };
+
+  const handleLanguageChange = (value: string) => {
+    updateLanguageMutation.mutate(value === '' ? null : value);
   };
 
   const isMember = Boolean(currentFeed.is_member);
@@ -748,30 +781,62 @@ export default function FeedDetail({ feed, onClose, onFeedDeleted }: FeedDetailP
             )}
 
             {isAdmin && (
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
-                <div className="flex flex-col gap-2">
-                  <div>
-                    <label className="text-sm font-medium text-gray-900">
-                      Auto-whitelist new episodes
-                    </label>
-                    <p className="text-xs text-gray-600">
-                      Overrides the global setting. Global default: {autoWhitelistDefaultLabel}.
-                    </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <div className="flex-1 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                  <div className="flex flex-col gap-2">
+                    <div>
+                      <label htmlFor="auto-whitelist-select" className="text-sm font-medium text-gray-900">
+                        Auto-whitelist new episodes
+                      </label>
+                      <p className="text-xs text-gray-600">
+                        Overrides the global setting. Global default: {autoWhitelistDefaultLabel}.
+                      </p>
+                    </div>
+                    <select
+                      id="auto-whitelist-select"
+                      value={autoWhitelistSelectValue}
+                      onChange={(e) => handleAutoWhitelistOverrideChange(e.target.value)}
+                      disabled={updateFeedSettingsMutation.isPending}
+                      className={`text-sm border border-gray-300 rounded-md px-3 py-2 bg-white ${
+                        updateFeedSettingsMutation.isPending
+                          ? 'opacity-60 cursor-not-allowed'
+                          : ''
+                      }`}
+                    >
+                      <option value="inherit">Use global setting ({autoWhitelistDefaultLabel})</option>
+                      <option value="on">On</option>
+                      <option value="off">Off</option>
+                    </select>
                   </div>
-                  <select
-                    value={autoWhitelistSelectValue}
-                    onChange={(e) => handleAutoWhitelistOverrideChange(e.target.value)}
-                    disabled={updateFeedSettingsMutation.isPending}
-                    className={`text-sm border border-gray-300 rounded-md px-3 py-2 bg-white ${
-                      updateFeedSettingsMutation.isPending
-                        ? 'opacity-60 cursor-not-allowed'
-                        : ''
-                    }`}
-                  >
-                    <option value="inherit">Use global setting ({autoWhitelistDefaultLabel})</option>
-                    <option value="on">On</option>
-                    <option value="off">Off</option>
-                  </select>
+                </div>
+
+                <div className="flex-1 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                  <div className="flex flex-col gap-2">
+                    <div>
+                      <label htmlFor="transcription-language-select" className="text-sm font-medium text-gray-900">
+                        Transcription language
+                      </label>
+                      <p className="text-xs text-gray-600">
+                        Overrides the global Whisper language setting for this feed.
+                      </p>
+                    </div>
+                    <select
+                      id="transcription-language-select"
+                      value={currentFeed.language ?? ''}
+                      onChange={(e) => handleLanguageChange(e.target.value)}
+                      disabled={updateLanguageMutation.isPending}
+                      className={`text-sm border border-gray-300 rounded-md px-3 py-2 bg-white ${
+                        updateLanguageMutation.isPending ? 'opacity-60 cursor-not-allowed' : ''
+                      }`}
+                    >
+                      <option value="">Use global setting</option>
+                      {WHISPER_LANGUAGES.map((lang) => (
+                        <option key={lang.code} value={lang.code}>
+                          {lang.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
               </div>
             )}

--- a/frontend/src/components/FeedList.tsx
+++ b/frontend/src/components/FeedList.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import type { Feed } from '../types';
+import { WHISPER_LANGUAGE_NAMES } from '../constants/whisperLanguages';
 
 interface FeedListProps {
   feeds: Feed[];
@@ -94,8 +95,18 @@ export default function FeedList({ feeds, onFeedDeleted: _onFeedDeleted, onFeedS
                     {feed.author && (
                       <p className="text-sm text-gray-600 mt-1">by {feed.author}</p>
                     )}
-                    <div className="flex items-center justify-between mt-2">
+                    <div className="flex items-center gap-2 mt-2">
                       <span className="text-xs text-gray-500">{feed.posts_count} episodes</span>
+                      {feed.language && (
+                        <span
+                          lang={feed.language}
+                          title={`Transcription language: ${WHISPER_LANGUAGE_NAMES[feed.language] ?? feed.language}`}
+                          className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase bg-gray-100 text-gray-700 border border-gray-200"
+                        >
+                          {feed.language}
+                        </span>
+                      )}
+                      <span className="flex-1" />
                       {showMembership && (
                         <div className="flex items-center gap-2">
                           <span

--- a/frontend/src/constants/whisperLanguages.ts
+++ b/frontend/src/constants/whisperLanguages.ts
@@ -1,0 +1,30 @@
+// Per-feed Whisper language vocabulary. Must stay in sync with the backend
+// VALID_WHISPER_LANGUAGES set in src/app/whisper_languages.py.
+
+export interface WhisperLanguageOption {
+  code: string;
+  name: string;
+}
+
+export const WHISPER_LANGUAGES: ReadonlyArray<WhisperLanguageOption> = [
+  { code: 'ar', name: 'Arabic' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'da', name: 'Danish' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'en', name: 'English' },
+  { code: 'fi', name: 'Finnish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'no', name: 'Norwegian' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'sv', name: 'Swedish' },
+];
+
+export const WHISPER_LANGUAGE_NAMES: Readonly<Record<string, string>> =
+  Object.fromEntries(WHISPER_LANGUAGES.map((l) => [l.code, l.name]));

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -82,9 +82,12 @@ export const feedsApi = {
     return response.data;
   },
 
-  addFeed: async (url: string): Promise<void> => {
+  addFeed: async (url: string, language?: string | null): Promise<void> => {
     const formData = new FormData();
     formData.append('url', url);
+    if (language) {
+      formData.append('language', language);
+    }
     await api.post('/feed', formData);
   },
 
@@ -142,7 +145,10 @@ export const feedsApi = {
 
   updateFeedSettings: async (
     feedId: number,
-    settings: { auto_whitelist_new_episodes_override: boolean | null }
+    // Server rejects {} with 400; require at least one settable field.
+    settings:
+      | { auto_whitelist_new_episodes_override: boolean | null; language?: string | null }
+      | { auto_whitelist_new_episodes_override?: boolean | null; language: string | null }
   ): Promise<Feed> => {
     const response = await api.patch(`/api/feeds/${feedId}/settings`, settings);
     return response.data;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface Feed {
   is_member?: boolean;
   is_active_subscription?: boolean;
   auto_whitelist_new_episodes_override?: boolean | null;
+  language?: string | null;
 }
 
 export interface Episode {

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -79,6 +79,26 @@ def _should_auto_whitelist_new_posts(feed: Feed, post: Optional[Post] = None) ->
     return False
 
 
+def ensure_requested_feed_language(feed: Feed, language: str | None) -> None:
+    """Persist an explicit add-feed language before any processing can be queued."""
+    if language is None or feed.language == language:
+        return
+
+    result = writer_client.action(
+        "update_feed_settings",
+        {
+            "feed_id": feed.id,
+            "language": language,
+            "only_if_unset": True,
+        },
+        wait=True,
+    )
+    if result is None or not result.success:
+        raise RuntimeError(getattr(result, "error", "Failed to set feed language"))
+
+    db.session.expire(feed, ["language"])
+
+
 def _get_base_url() -> str:
     try:
         # Check various ways HTTP/2 pseudo-headers might be available
@@ -187,7 +207,7 @@ number_of_episodes_to_whitelist_from_archive_of_new_feed setting: {entry.title}"
     logger.info(f"Feed with ID: {feed.id} refreshed")
 
 
-def add_or_refresh_feed(url: str) -> Feed:
+def add_or_refresh_feed(url: str, language: str | None = None) -> Feed:
     feed_data = fetch_feed(url)
     if "title" not in feed_data.feed:
         logger.error("Invalid feed URL")
@@ -195,13 +215,14 @@ def add_or_refresh_feed(url: str) -> Feed:
 
     feed = Feed.query.filter_by(rss_url=url).first()
     if feed:
+        ensure_requested_feed_language(feed, language)
         refresh_feed(feed)
     else:
-        feed = add_feed(feed_data)
+        feed = add_feed(feed_data, language=language)
     return feed  # type: ignore[no-any-return]
 
 
-def add_feed(feed_data: feedparser.FeedParserDict) -> Feed:
+def add_feed(feed_data: feedparser.FeedParserDict, language: str | None = None) -> Feed:
     logger.info(f"Storing feed: {feed_data.feed.title}")
     try:
         feed_dict = {
@@ -211,6 +232,8 @@ def add_feed(feed_data: feedparser.FeedParserDict) -> Feed:
             "rss_url": feed_data.href,
             "image_url": feed_data.feed.image.href,
         }
+        if language is not None:
+            feed_dict["language"] = language
 
         # Create a temporary feed object to use make_post helper
         temp_feed = Feed(**feed_dict)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from datetime import datetime
 
+import sqlalchemy as sa
 from sqlalchemy.orm import validates
 
 from app.auth.passwords import hash_password, verify_password
@@ -31,6 +32,7 @@ class Feed(db.Model):  # type: ignore[name-defined, misc]
     rss_url = db.Column(db.Text, unique=True, nullable=False)
     image_url = db.Column(db.Text)
     auto_whitelist_new_episodes_override = db.Column(db.Boolean, nullable=True)
+    language = db.Column(db.Text, nullable=True)
 
     posts = db.relationship(
         "Post", backref="feed", lazy=True, order_by="Post.release_date.desc()"
@@ -196,12 +198,18 @@ class ModelCall(db.Model):  # type: ignore[name-defined, misc]
     status = db.Column(db.String, nullable=False, default="pending")
     error_message = db.Column(db.Text, nullable=True)
     retry_attempts = db.Column(db.Integer, nullable=False, default=0)
+    # NULL = LLM/legacy row; set = Whisper row. Doubles as the discriminator
+    # for the two partial unique indexes below.
+    language = db.Column(db.Text, nullable=True)
 
     identifications = db.relationship(
         "Identification", backref="model_call", lazy="dynamic"
     )
     post = db.relationship("Post", backref=db.backref("model_calls", lazy="dynamic"))
 
+    # Two partial unique indexes — whisper rows are keyed by (post, model,
+    # language) since the same audio can be transcribed in multiple languages,
+    # while non-whisper (LLM) rows preserve the legacy chunk-based key.
     __table_args__ = (
         db.Index(
             "ix_model_call_post_chunk_model",
@@ -210,6 +218,15 @@ class ModelCall(db.Model):  # type: ignore[name-defined, misc]
             "last_segment_sequence_num",
             "model_name",
             unique=True,
+            sqlite_where=sa.text("language IS NULL"),
+        ),
+        db.Index(
+            "ix_model_call_whisper_post_model_lang",
+            "post_id",
+            "model_name",
+            "language",
+            unique=True,
+            sqlite_where=sa.text("language IS NOT NULL"),
         ),
     )
 

--- a/src/app/routes/feed_routes.py
+++ b/src/app/routes/feed_routes.py
@@ -31,6 +31,7 @@ from app.auth.service import update_user_last_active
 from app.extensions import db
 from app.feeds import (
     add_or_refresh_feed,
+    ensure_requested_feed_language,
     generate_aggregate_feed_xml,
     generate_feed_xml,
     is_feed_active_for_user,
@@ -43,6 +44,7 @@ from app.models import (
     User,
     UserFeed,
 )
+from app.whisper_languages import normalize_whisper_language, whisper_language_error
 from app.writer.client import writer_client
 from podcast_processor.podcast_downloader import sanitize_title
 from shared.processing_paths import get_in_root, get_srv_root
@@ -50,7 +52,6 @@ from shared.processing_paths import get_in_root, get_srv_root
 from .auth_routes import _require_authenticated_user as _auth_get_user
 
 logger = logging.getLogger("global_logger")
-
 
 feed_bp = Blueprint("feed", __name__)
 
@@ -189,6 +190,17 @@ def _check_feed_allowance(user: User, url: str) -> Optional[ResponseReturnValue]
     return None
 
 
+def _join_feed_and_whitelist_first_post(feed: Feed, user: User | None) -> None:
+    if user:
+        created, previous_count = _ensure_user_feed_membership(feed, user.id)
+        if created and previous_count == 0:
+            _whitelist_latest_for_first_member(feed, getattr(user, "id", None))
+        return
+
+    if not is_auth_enabled() and UserFeed.query.filter_by(feed_id=feed.id).count() == 0:
+        _whitelist_latest_for_first_member(feed, None)
+
+
 @feed_bp.route("/feed", methods=["POST"])
 def add_feed() -> ResponseReturnValue:
     settings = current_app.config.get("AUTH_SETTINGS")
@@ -200,6 +212,11 @@ def add_feed() -> ResponseReturnValue:
     url = request.form.get("url")
     if not url:
         return make_response(("URL is required", 400))
+
+    try:
+        language = normalize_whisper_language(request.form.get("language"))
+    except ValueError:
+        return make_response((whisper_language_error("empty"), 400))
 
     url = fix_url(url)
 
@@ -215,15 +232,9 @@ def add_feed() -> ResponseReturnValue:
             if allowance_error:
                 return allowance_error
 
-        feed = add_or_refresh_feed(url)
-        if user:
-            created, previous_count = _ensure_user_feed_membership(feed, user.id)
-            if created and previous_count == 0:
-                _whitelist_latest_for_first_member(feed, getattr(user, "id", None))
-        elif not is_auth_enabled():
-            # In no-auth mode, if this feed has no members, trigger whitelisting for the latest post.
-            if UserFeed.query.filter_by(feed_id=feed.id).count() == 0:
-                _whitelist_latest_for_first_member(feed, None)
+        feed = add_or_refresh_feed(url, language=language)
+        ensure_requested_feed_language(feed, language)
+        _join_feed_and_whitelist_first_post(feed, user)
 
         app = cast(Any, current_app)._get_current_object()
         Thread(
@@ -476,25 +487,38 @@ def update_feed_settings_endpoint(feed_id: int) -> ResponseReturnValue:
         return error_response
 
     payload = request.get_json(silent=True) or {}
-    if "auto_whitelist_new_episodes_override" not in payload:
+    if (
+        "auto_whitelist_new_episodes_override" not in payload
+        and "language" not in payload
+    ):
         return jsonify({"error": "No settings provided."}), 400
 
-    override = payload.get("auto_whitelist_new_episodes_override")
-    if override is not None and not isinstance(override, bool):
-        return (
-            jsonify(
-                {
-                    "error": "auto_whitelist_new_episodes_override must be a boolean or null."
-                }
-            ),
-            400,
-        )
+    writer_payload: dict[str, Any] = {"feed_id": feed_id}
 
-    result = writer_client.action(
-        "update_feed_settings",
-        {"feed_id": feed_id, "auto_whitelist_new_episodes_override": override},
-        wait=True,
-    )
+    if "auto_whitelist_new_episodes_override" in payload:
+        override = payload.get("auto_whitelist_new_episodes_override")
+        if override is not None and not isinstance(override, bool):
+            return (
+                jsonify(
+                    {
+                        "error": "auto_whitelist_new_episodes_override must be a boolean or null."
+                    }
+                ),
+                400,
+            )
+        writer_payload["auto_whitelist_new_episodes_override"] = override
+
+    if "language" in payload:
+        try:
+            language = normalize_whisper_language(payload.get("language"))
+        except ValueError:
+            return (
+                jsonify({"error": whisper_language_error("null")}),
+                400,
+            )
+        writer_payload["language"] = language
+
+    result = writer_client.action("update_feed_settings", writer_payload, wait=True)
     if result is None or not result.success:
         return (
             jsonify({"error": getattr(result, "error", "Failed to update feed")}),
@@ -937,6 +961,7 @@ def _serialize_feed(
         "auto_whitelist_new_episodes_override": getattr(
             feed, "auto_whitelist_new_episodes_override", None
         ),
+        "language": feed.language,
         "posts_count": len(feed.posts),
         "member_count": len(member_ids),
         "is_member": is_member,

--- a/src/app/whisper_languages.py
+++ b/src/app/whisper_languages.py
@@ -1,0 +1,34 @@
+VALID_WHISPER_LANGUAGES = frozenset(
+    {
+        "ar",
+        "zh",
+        "da",
+        "nl",
+        "en",
+        "fi",
+        "fr",
+        "de",
+        "it",
+        "ja",
+        "ko",
+        "no",
+        "pl",
+        "pt",
+        "ru",
+        "es",
+        "sv",
+    }
+)
+VALID_WHISPER_LANGUAGES_STR = ", ".join(sorted(VALID_WHISPER_LANGUAGES))
+
+
+def normalize_whisper_language(value: object) -> str | None:
+    if value == "" or value is None:
+        return None
+    if not isinstance(value, str) or value not in VALID_WHISPER_LANGUAGES:
+        raise ValueError("invalid whisper language")
+    return value
+
+
+def whisper_language_error(empty_label: str) -> str:
+    return f"language must be one of: {VALID_WHISPER_LANGUAGES_STR}, or {empty_label}."

--- a/src/app/writer/actions/feeds.py
+++ b/src/app/writer/actions/feeds.py
@@ -120,8 +120,18 @@ def update_feed_settings_action(params: Dict[str, Any]) -> Dict[str, Any]:
             "auto_whitelist_new_episodes_override"
         )
 
+    if "language" in params:
+        # When called from POST /feed for a newly-added feed, the route
+        # passes only_if_unset=True so a concurrent add of the same RSS
+        # URL — or a retry after a partial failure — can't overwrite a
+        # language that was already set inside the serialized writer.
+        if params.get("only_if_unset") and feed.language is not None:
+            pass
+        else:
+            feed.language = params["language"]
+
     db.session.flush()
-    return {"feed_id": feed.id}
+    return {"feed_id": feed.id, "language": feed.language}
 
 
 def increment_download_count_action(params: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/app/writer/actions/processor.py
+++ b/src/app/writer/actions/processor.py
@@ -78,6 +78,7 @@ def upsert_whisper_model_call_action(params: Dict[str, Any]) -> Dict[str, Any]:
     first_seq = params.get("first_segment_sequence_num", 0)
     last_seq = params.get("last_segment_sequence_num", -1)
     prompt = params.get("prompt") or "Whisper transcription job"
+    language = params.get("language")
 
     if post_id is None or model_name is None:
         raise ValueError("post_id and model_name are required")
@@ -91,16 +92,18 @@ def upsert_whisper_model_call_action(params: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     def _query() -> ModelCall | None:
+        # The partial unique index on (post, model_name, language) guarantees
+        # at most one matching row. We match on those three columns (not the
+        # seq nums) so that a previously-finalized row gets reused and reset
+        # rather than colliding with a new placeholder.
         return (
             db.session.query(ModelCall)
             .filter_by(
                 post_id=int(post_id),
                 model_name=str(model_name),
-                first_segment_sequence_num=int(first_seq),
-                last_segment_sequence_num=int(last_seq),
+                language=language,
             )
-            .order_by(ModelCall.timestamp.desc())
-            .first()
+            .one_or_none()
         )
 
     model_call = _query()
@@ -111,10 +114,7 @@ def upsert_whisper_model_call_action(params: Dict[str, Any]) -> Dict[str, Any]:
             first_segment_sequence_num=int(first_seq),
             last_segment_sequence_num=int(last_seq),
             prompt=str(prompt),
-            status=str(reset_fields.get("status") or "pending"),
-            retry_attempts=int(reset_fields.get("retry_attempts") or 0),
-            error_message=reset_fields.get("error_message"),
-            response=reset_fields.get("response"),
+            language=language,
             timestamp=datetime.utcnow(),
         )
         db.session.add(model_call)
@@ -126,11 +126,15 @@ def upsert_whisper_model_call_action(params: Dict[str, Any]) -> Dict[str, Any]:
             if model_call is None:
                 raise
 
+    # Reset to placeholder seq nums (overwriting whatever a finalized row had);
+    # reset_fields then resets status / retry_attempts / etc.
+    model_call.first_segment_sequence_num = int(first_seq)
+    model_call.last_segment_sequence_num = int(last_seq)
     for k, v in reset_fields.items():
         if hasattr(model_call, k):
             setattr(model_call, k, v)
-
     db.session.flush()
+
     return {"model_call_id": int(model_call.id)}
 
 
@@ -205,6 +209,37 @@ def replace_transcription_action(params: Dict[str, Any]) -> Dict[str, Any]:
             mc.response = f"{len(payload)} segments transcribed."
             mc.status = "success"
             mc.error_message = None
+
+            # When this is a real language change — i.e. a prior whisper
+            # ModelCall for another language exists — invalidate downstream
+            # caches:
+            #   1. Sibling whisper ModelCalls are marked `superseded` so the
+            #      cache lookup doesn't return them pointing at someone
+            #      else's segments.
+            #   2. LLM ModelCalls (language IS NULL — ad classifier and
+            #      similar) are deleted: their stored prompts were built
+            #      from the prior transcript content and their responses
+            #      classified ads against text that no longer exists.
+            # Gating LLM-delete on "supersede actually fired" avoids nuking
+            # ad-classifier caches on the first post-migration whisper run,
+            # where the only prior whisper row is a legacy one with
+            # language=NULL (already excluded from the supersede filter).
+            if mc.language is not None:
+                superseded = (
+                    db.session.query(ModelCall)
+                    .filter(
+                        ModelCall.post_id == post_id_i,
+                        ModelCall.id != int(model_call_id),
+                        ModelCall.status == "success",
+                        ModelCall.language.isnot(None),
+                    )
+                    .update({ModelCall.status: "superseded"}, synchronize_session=False)
+                )
+                if superseded:
+                    db.session.query(ModelCall).filter(
+                        ModelCall.post_id == post_id_i,
+                        ModelCall.language.is_(None),
+                    ).delete(synchronize_session=False)
 
     db.session.flush()
     return {"post_id": post_id_i, "segment_count": len(payload)}

--- a/src/migrations/versions/35adef5e4c3e_add_language_to_feed.py
+++ b/src/migrations/versions/35adef5e4c3e_add_language_to_feed.py
@@ -1,0 +1,25 @@
+"""add language to feed
+
+Revision ID: 35adef5e4c3e
+Revises: 2e25a15d11de
+Create Date: 2026-05-19 12:47:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "35adef5e4c3e"
+down_revision = "2e25a15d11de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("feed", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("language", sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("feed", schema=None) as batch_op:
+        batch_op.drop_column("language")

--- a/src/migrations/versions/a7c1b9e2d4f5_add_language_to_model_call.py
+++ b/src/migrations/versions/a7c1b9e2d4f5_add_language_to_model_call.py
@@ -1,0 +1,76 @@
+"""add language to model_call
+
+Revision ID: a7c1b9e2d4f5
+Revises: 35adef5e4c3e
+Create Date: 2026-05-19 14:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a7c1b9e2d4f5"
+down_revision = "35adef5e4c3e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Nullable so existing rows keep NULL. The whisper cache lookup filters by
+    # language, so legacy rows force a one-time re-transcription on next process.
+    with op.batch_alter_table("model_call", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("language", sa.Text(), nullable=True))
+        # Restrict the existing unique index to rows with NULL language (LLM /
+        # legacy callers) so non-whisper uniqueness behaves exactly as before.
+        batch_op.drop_index("ix_model_call_post_chunk_model")
+        batch_op.create_index(
+            "ix_model_call_post_chunk_model",
+            [
+                "post_id",
+                "first_segment_sequence_num",
+                "last_segment_sequence_num",
+                "model_name",
+            ],
+            unique=True,
+            sqlite_where=sa.text("language IS NULL"),
+        )
+        # Whisper rows are keyed by (post, model, language) — one row per
+        # (post, model, language) regardless of segment count.
+        batch_op.create_index(
+            "ix_model_call_whisper_post_model_lang",
+            ["post_id", "model_name", "language"],
+            unique=True,
+            sqlite_where=sa.text("language IS NOT NULL"),
+        )
+
+
+def downgrade():
+    # Upgrade allowed multiple whisper ModelCall rows per (post, model) keyed
+    # by language. The legacy unique index doesn't include language, so if two
+    # rows share (post, first_seq, last_seq, model_name) but differ only in
+    # language, recreating that index would collide. Collapse duplicates
+    # first, keeping the most recently updated row.
+    op.execute(
+        """
+        DELETE FROM model_call
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM model_call
+            GROUP BY post_id, first_segment_sequence_num,
+                     last_segment_sequence_num, model_name
+        )
+        """
+    )
+    with op.batch_alter_table("model_call", schema=None) as batch_op:
+        batch_op.drop_index("ix_model_call_whisper_post_model_lang")
+        batch_op.drop_index("ix_model_call_post_chunk_model")
+        batch_op.create_index(
+            "ix_model_call_post_chunk_model",
+            [
+                "post_id",
+                "first_segment_sequence_num",
+                "last_segment_sequence_num",
+                "model_name",
+            ],
+            unique=True,
+        )
+        batch_op.drop_column("language")

--- a/src/podcast_processor/podcast_processor.py
+++ b/src/podcast_processor/podcast_processor.py
@@ -339,7 +339,9 @@ class PodcastProcessor:
         self.status_manager.update_job_status(
             job, "running", 2, "Transcribing audio", 50.0
         )
-        transcript_segments = self.transcription_manager.transcribe(post)
+        transcript_segments = self.transcription_manager.transcribe(
+            post, language=post.feed.language
+        )
         self._raise_if_cancelled(job, 2, cancel_callback)
 
         # Step 3: Classify ad segments

--- a/src/podcast_processor/transcribe.py
+++ b/src/podcast_processor/transcribe.py
@@ -28,7 +28,7 @@ class Transcriber(ABC):
         pass
 
     @abstractmethod
-    def transcribe(self, audio_file_path: str) -> List[Segment]:
+    def transcribe(self, audio_file_path: str, language: str) -> List[Segment]:
         pass
 
 
@@ -57,7 +57,9 @@ class TestWhisperTranscriber(Transcriber):
     def model_name(self) -> str:
         return "test_whisper"
 
-    def transcribe(self, _: str) -> List[Segment]:
+    def transcribe(  # pylint: disable=unused-argument
+        self, _: str, language: str
+    ) -> List[Segment]:
         self.logger.info("Using test whisper")
         return [
             Segment(start=0, end=1, text="This is a test"),
@@ -85,7 +87,7 @@ class LocalWhisperTranscriber(Transcriber):
     def local_seg_to_seg(local_segments: List[LocalTranscriptSegment]) -> List[Segment]:
         return [seg.to_segment() for seg in local_segments]
 
-    def transcribe(self, audio_file_path: str) -> List[Segment]:
+    def transcribe(self, audio_file_path: str, language: str) -> List[Segment]:
         # Import whisper only when needed to avoid CUDA dependencies during module import
         try:
             import whisper  # type: ignore[import-untyped]
@@ -103,7 +105,7 @@ class LocalWhisperTranscriber(Transcriber):
 
         self.logger.info("Beginning transcription")
         start = time.time()
-        result = model.transcribe(audio_file_path, fp16=False, language="English")
+        result = model.transcribe(audio_file_path, fp16=False, language=language)
         end = time.time()
         elapsed = end - start
         self.logger.info(f"Transcription completed in {elapsed}")
@@ -129,7 +131,7 @@ class OpenAIWhisperTranscriber(Transcriber):
     def model_name(self) -> str:
         return self.config.model  # e.g. "whisper-1"
 
-    def transcribe(self, audio_file_path: str) -> List[Segment]:
+    def transcribe(self, audio_file_path: str, language: str) -> List[Segment]:
         self.logger.info(
             "[WHISPER_REMOTE] Starting remote whisper transcription for: %s",
             audio_file_path,
@@ -153,7 +155,7 @@ class OpenAIWhisperTranscriber(Transcriber):
                 len(chunks),
                 chunk_path,
             )
-            segments = self.get_segments_for_chunk(str(chunk_path))
+            segments = self.get_segments_for_chunk(str(chunk_path), language=language)
             self.logger.info(
                 "[WHISPER_REMOTE] Chunk %d/%d complete: %d segments",
                 idx + 1,
@@ -191,7 +193,9 @@ class OpenAIWhisperTranscriber(Transcriber):
 
         return segments
 
-    def get_segments_for_chunk(self, chunk_path: str) -> List[TranscriptionSegment]:
+    def get_segments_for_chunk(
+        self, chunk_path: str, language: str
+    ) -> List[TranscriptionSegment]:
         with open(chunk_path, "rb") as f:
             self.logger.info(
                 "[WHISPER_API_CALL] Sending chunk to API: %s (timeout=%ds)",
@@ -203,7 +207,7 @@ class OpenAIWhisperTranscriber(Transcriber):
                 model=self.config.model,
                 file=f,
                 timestamp_granularities=["segment"],
-                language=self.config.language,
+                language=language,
                 response_format="verbose_json",
             )
 
@@ -237,7 +241,7 @@ class GroqWhisperTranscriber(Transcriber):
     def model_name(self) -> str:
         return f"groq_{self.config.model}"
 
-    def transcribe(self, audio_file_path: str) -> List[Segment]:
+    def transcribe(self, audio_file_path: str, language: str) -> List[Segment]:
         self.logger.info(
             "[WHISPER_GROQ] Starting Groq whisper transcription for: %s",
             audio_file_path,
@@ -259,7 +263,7 @@ class GroqWhisperTranscriber(Transcriber):
                 len(chunks),
                 chunk_path,
             )
-            segments = self.get_segments_for_chunk(str(chunk_path))
+            segments = self.get_segments_for_chunk(str(chunk_path), language=language)
             self.logger.info(
                 "[WHISPER_GROQ] Chunk %d/%d complete: %d segments",
                 idx + 1,
@@ -297,14 +301,16 @@ class GroqWhisperTranscriber(Transcriber):
 
         return segments
 
-    def get_segments_for_chunk(self, chunk_path: str) -> List[GroqTranscriptionSegment]:
+    def get_segments_for_chunk(
+        self, chunk_path: str, language: str
+    ) -> List[GroqTranscriptionSegment]:
 
         self.logger.info("[GROQ_API_CALL] Sending chunk to Groq API: %s", chunk_path)
         transcription = self.client.audio.transcriptions.create(
             file=Path(chunk_path),
             model=self.config.model,
             response_format="verbose_json",  # Ensure segments are included
-            language=self.config.language,
+            language=language,
         )
         self.logger.info(
             "[GROQ_API_CALL] Received response from Groq API for: %s", chunk_path

--- a/src/podcast_processor/transcription_manager.py
+++ b/src/podcast_processor/transcription_manager.py
@@ -20,6 +20,8 @@ from .transcribe import (
     Transcriber,
 )
 
+DEFAULT_LANGUAGE = "en"
+
 
 class TranscriptionManager:
     """Handles the transcription of podcast audio files."""
@@ -59,8 +61,14 @@ class TranscriptionManager:
             return GroqWhisperTranscriber(self.logger, self.config.whisper)
         raise ValueError(f"unhandled whisper config {self.config.whisper}")
 
+    def _effective_language(self, language: Optional[str]) -> str:
+        """The language Whisper will actually see: per-feed override > global > default."""
+        if language:
+            return language
+        return getattr(self.config.whisper, "language", DEFAULT_LANGUAGE)
+
     def _check_existing_transcription(
-        self, post: Post
+        self, post: Post, language: str
     ) -> Optional[List[TranscriptSegment]]:
         """Checks for existing successful transcription and returns segments if valid.
 
@@ -78,15 +86,14 @@ class TranscriptionManager:
             else self.db_session.query(TranscriptSegment)
         )
 
-        existing_whisper_call = (
-            model_call_query.filter_by(
-                post_id=post.id,
-                model_name=self.transcriber.model_name,
-                status="success",
-            )
-            .order_by(ModelCall.timestamp.desc())
-            .first()
-        )
+        # At most one row matches: the (post, model_name, language) partial
+        # unique index allows only one whisper ModelCall per language per post.
+        existing_whisper_call = model_call_query.filter_by(
+            post_id=post.id,
+            model_name=self.transcriber.model_name,
+            status="success",
+            language=language,
+        ).one_or_none()
 
         if existing_whisper_call:
             self.logger.info(
@@ -119,7 +126,7 @@ class TranscriptionManager:
             )
         return None
 
-    def _get_or_create_whisper_model_call(self, post: Post) -> ModelCall:
+    def _get_or_create_whisper_model_call(self, post: Post, language: str) -> ModelCall:
         """Create or reuse the placeholder ModelCall row for a Whisper run via writer."""
         result = writer_client.action(
             "upsert_whisper_model_call",
@@ -129,6 +136,7 @@ class TranscriptionManager:
                 "first_segment_sequence_num": 0,
                 "last_segment_sequence_num": -1,
                 "prompt": "Whisper transcription job",
+                "language": language,
             },
             wait=True,
         )
@@ -143,7 +151,9 @@ class TranscriptionManager:
             raise RuntimeError(f"ModelCall {model_call_id} not found after upsert")
         return model_call
 
-    def transcribe(self, post: Post) -> List[TranscriptSegment]:
+    def transcribe(
+        self, post: Post, language: Optional[str] = None
+    ) -> List[TranscriptSegment]:
         """
         Transcribes a podcast audio file, or retrieves existing transcription.
 
@@ -153,16 +163,19 @@ class TranscriptionManager:
         Returns:
             A list of TranscriptSegment objects with the transcription results
         """
+        effective_language = self._effective_language(language)
         self.logger.info(
-            f"Starting transcription process for post {post.id} using {self.transcriber.model_name}"
+            f"Starting transcription process for post {post.id} using {self.transcriber.model_name} (language={effective_language})"
         )
 
-        existing_segments = self._check_existing_transcription(post)
+        existing_segments = self._check_existing_transcription(post, effective_language)
         if existing_segments is not None:
             return existing_segments
 
         # Create or reuse the ModelCall record for this transcription attempt
-        current_whisper_call = self._get_or_create_whisper_model_call(post)
+        current_whisper_call = self._get_or_create_whisper_model_call(
+            post, effective_language
+        )
         self.logger.info(
             f"Prepared Whisper ModelCall {current_whisper_call.id} for post {post.id}."
         )
@@ -174,7 +187,9 @@ class TranscriptionManager:
             # Expire session state before long-running transcription to avoid stale locks
             self.db_session.expire_all()
 
-            pydantic_segments = self.transcriber.transcribe(post.unprocessed_audio_path)
+            pydantic_segments = self.transcriber.transcribe(
+                post.unprocessed_audio_path, language=effective_language
+            )
             self.logger.info(
                 f"[TRANSCRIBE_COMPLETE] Transcription by {self.transcriber.model_name} for post {post.id} resulted in {len(pydantic_segments)} segments."
             )

--- a/src/tests/test_feed_routes.py
+++ b/src/tests/test_feed_routes.py
@@ -1,0 +1,363 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from flask import Blueprint
+
+from app.extensions import db
+from app.models import Feed
+from app.routes.feed_routes import feed_bp
+
+
+def _make_client(app):
+    app.testing = True
+    app.register_blueprint(feed_bp)
+    # add_feed redirects to main.index — stub it so url_for resolves.
+    if "main" not in app.blueprints:
+        main_bp = Blueprint("main", __name__)
+
+        @main_bp.route("/", endpoint="index")
+        def _index():
+            return "ok"
+
+        app.register_blueprint(main_bp)
+    return app.test_client()
+
+
+def _make_feed(rss_url="http://example.com/feed.rss", language=None):
+    feed = Feed(title="Test Feed", rss_url=rss_url, language=language)
+    db.session.add(feed)
+    db.session.commit()
+    return feed
+
+
+def test_update_feed_settings_language_valid(app):
+    with app.app_context():
+        feed = _make_feed()
+        client = _make_client(app)
+
+        with mock.patch("app.routes.feed_routes.writer_client") as mock_writer:
+
+            def side_effect(action, params, wait=False):
+                if action == "update_feed_settings":
+                    assert params == {"feed_id": feed.id, "language": "de"}
+                    Feed.query.filter_by(id=params["feed_id"]).update(
+                        {"language": params["language"]}
+                    )
+                    db.session.commit()
+                return SimpleNamespace(success=True)
+
+            mock_writer.action.side_effect = side_effect
+
+            response = client.patch(
+                f"/api/feeds/{feed.id}/settings",
+                json={"language": "de"},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["language"] == "de"
+
+
+def test_update_feed_settings_language_null_clears(app):
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/feed2.rss", language="de")
+        client = _make_client(app)
+
+        with mock.patch("app.routes.feed_routes.writer_client") as mock_writer:
+
+            def side_effect(action, params, wait=False):
+                if action == "update_feed_settings":
+                    assert params == {"feed_id": feed.id, "language": None}
+                    Feed.query.filter_by(id=params["feed_id"]).update(
+                        {"language": params["language"]}
+                    )
+                    db.session.commit()
+                return SimpleNamespace(success=True)
+
+            mock_writer.action.side_effect = side_effect
+
+            response = client.patch(
+                f"/api/feeds/{feed.id}/settings",
+                json={"language": None},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["language"] is None
+
+
+def test_update_feed_settings_language_invalid_returns_400(app):
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/feed3.rss")
+        client = _make_client(app)
+
+        response = client.patch(
+            f"/api/feeds/{feed.id}/settings",
+            json={"language": "klingon"},
+        )
+
+        assert response.status_code == 400
+        assert "language must be one of" in response.get_json()["error"]
+
+
+def test_update_feed_settings_language_non_string_returns_400(app):
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/feed5.rss")
+        client = _make_client(app)
+
+        response = client.patch(
+            f"/api/feeds/{feed.id}/settings",
+            json={"language": ["en", "de"]},
+        )
+
+        assert response.status_code == 400
+        assert "language must be one of" in response.get_json()["error"]
+
+
+def test_add_feed_with_language_on_new_feed(app):
+    """Adding a brand-new feed with a language persists it via the writer."""
+    with app.app_context():
+        client = _make_client(app)
+        url = "http://example.com/add-lang.rss"
+
+        def fake_add_or_refresh(_url, language=None):
+            assert language == "de"
+            feed = Feed(title="New Feed", rss_url=_url, language=language)
+            db.session.add(feed)
+            db.session.commit()
+            return feed
+
+        with mock.patch(
+            "app.routes.feed_routes.add_or_refresh_feed",
+            side_effect=fake_add_or_refresh,
+        ), mock.patch("app.routes.feed_routes.Thread"), mock.patch(
+            "app.routes.feed_routes.writer_client"
+        ) as mock_writer:
+
+            def writer_side_effect(action, params, wait=False):
+                assert action != "update_feed_settings"
+                return SimpleNamespace(success=True)
+
+            mock_writer.action.side_effect = writer_side_effect
+
+            response = client.post(
+                "/feed",
+                data={"url": url, "language": "de"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (200, 302), response.data
+        feed = Feed.query.filter_by(rss_url=url).first()
+        assert feed is not None
+        assert feed.language == "de"
+        update_calls = [
+            c
+            for c in mock_writer.action.call_args_list
+            if c.args[0] == "update_feed_settings"
+        ]
+        assert len(update_calls) == 0
+
+
+def test_add_feed_existing_language_preserved_in_writer(app):
+    """Re-adding an existing feed always calls the writer with only_if_unset=True;
+    the writer itself preserves any prior language. This serializes the
+    race-vs-retry semantics inside the writer rather than the request session.
+    """
+    with app.app_context():
+        client = _make_client(app)
+        existing = _make_feed(
+            rss_url="http://example.com/add-preserve.rss", language="fr"
+        )
+
+        with mock.patch(
+            "app.routes.feed_routes.add_or_refresh_feed", return_value=existing
+        ), mock.patch("app.routes.feed_routes.Thread"), mock.patch(
+            "app.routes.feed_routes.writer_client"
+        ) as mock_route_writer, mock.patch(
+            "app.feeds.writer_client"
+        ) as mock_feed_writer:
+            mock_route_writer.action.return_value = SimpleNamespace(success=True)
+            mock_feed_writer.action.return_value = SimpleNamespace(success=True)
+            response = client.post(
+                "/feed",
+                data={"url": "http://example.com/add-preserve.rss", "language": "de"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (200, 302), response.data
+        update_calls = [
+            c
+            for c in mock_feed_writer.action.call_args_list
+            if c.args[0] == "update_feed_settings"
+        ]
+        assert len(update_calls) == 1
+        assert update_calls[0].args[1].get("only_if_unset") is True
+
+
+def test_add_feed_sets_existing_feed_language_before_whitelisting(app):
+    """Existing feeds get the requested language before first-member processing."""
+    with app.app_context():
+        client = _make_client(app)
+        existing = _make_feed(rss_url="http://example.com/order.rss")
+        actions: list[str] = []
+
+        def route_writer_side_effect(action, params, wait=False):
+            actions.append(action)
+            if action == "whitelist_latest_post_for_feed":
+                return SimpleNamespace(success=True, data={"updated": False})
+            return SimpleNamespace(success=True, data={})
+
+        def feed_writer_side_effect(action, params, wait=False):
+            actions.append(action)
+            Feed.query.filter_by(id=params["feed_id"]).update(
+                {"language": params["language"]}
+            )
+            db.session.commit()
+            return SimpleNamespace(success=True, data={"language": params["language"]})
+
+        with mock.patch(
+            "app.routes.feed_routes.add_or_refresh_feed", return_value=existing
+        ), mock.patch("app.routes.feed_routes.Thread"), mock.patch(
+            "app.routes.feed_routes.writer_client"
+        ) as mock_route_writer, mock.patch(
+            "app.feeds.writer_client"
+        ) as mock_feed_writer:
+            mock_route_writer.action.side_effect = route_writer_side_effect
+            mock_feed_writer.action.side_effect = feed_writer_side_effect
+
+            response = client.post(
+                "/feed",
+                data={"url": "http://example.com/order.rss", "language": "de"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (200, 302), response.data
+        assert actions[:2] == [
+            "update_feed_settings",
+            "whitelist_latest_post_for_feed",
+        ]
+        db.session.refresh(existing)
+        assert existing.language == "de"
+
+
+def test_update_feed_settings_action_only_if_unset(app):
+    """The writer action skips the language write when only_if_unset=True
+    and the feed already has a language."""
+    from app.writer.actions.feeds import update_feed_settings_action
+
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/only-if-unset.rss", language="fr")
+        result = update_feed_settings_action(
+            {"feed_id": feed.id, "language": "de", "only_if_unset": True}
+        )
+        db.session.refresh(feed)
+        assert feed.language == "fr"
+        assert result["language"] == "fr"
+
+        result2 = update_feed_settings_action({"feed_id": feed.id, "language": "de"})
+        db.session.refresh(feed)
+        assert feed.language == "de"
+        assert result2["language"] == "de"
+
+
+def test_update_feed_settings_action_only_if_unset_writes_when_null(app):
+    """only_if_unset still writes when the prior value was null."""
+    from app.writer.actions.feeds import update_feed_settings_action
+
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/only-if-null.rss")
+        assert feed.language is None
+        update_feed_settings_action(
+            {"feed_id": feed.id, "language": "de", "only_if_unset": True}
+        )
+        db.session.refresh(feed)
+        assert feed.language == "de"
+
+
+def test_add_feed_writer_failure_returns_500_before_enqueue(app):
+    """If an explicit language write fails, the request fails before jobs enqueue."""
+    with app.app_context():
+        client = _make_client(app)
+        url = "http://example.com/add-writer-fail.rss"
+        created: dict[str, Feed] = {}
+
+        def fake_add_or_refresh(_url, language=None):
+            feed = Feed(title="WF", rss_url=_url)
+            db.session.add(feed)
+            db.session.commit()
+            created["feed"] = feed
+            return feed
+
+        with mock.patch(
+            "app.routes.feed_routes.add_or_refresh_feed",
+            side_effect=fake_add_or_refresh,
+        ), mock.patch("app.routes.feed_routes.Thread") as mock_thread, mock.patch(
+            "app.routes.feed_routes.writer_client"
+        ) as mock_route_writer, mock.patch(
+            "app.feeds.writer_client"
+        ) as mock_feed_writer:
+            mock_route_writer.action.return_value = SimpleNamespace(success=True)
+            mock_feed_writer.action.return_value = SimpleNamespace(
+                success=False, error="boom"
+            )
+            response = client.post(
+                "/feed",
+                data={"url": url, "language": "de"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 500, response.data
+        feed = Feed.query.filter_by(rss_url=url).first()
+        assert feed is not None
+        assert feed.language is None
+        mock_thread.assert_not_called()
+        assert [c.args[0] for c in mock_feed_writer.action.call_args_list] == [
+            "update_feed_settings"
+        ]
+        mock_route_writer.action.assert_not_called()
+
+
+def test_add_feed_invalid_language_returns_400(app):
+    with app.app_context():
+        client = _make_client(app)
+
+        response = client.post(
+            "/feed",
+            data={"url": "http://example.com/add-bad.rss", "language": "klingon"},
+        )
+
+        assert response.status_code == 400
+        assert b"language must be one of" in response.data
+
+
+def test_add_feed_no_language_leaves_null(app):
+    with app.app_context():
+        client = _make_client(app)
+        existing = _make_feed(rss_url="http://example.com/add-nolang.rss")
+
+        with mock.patch(
+            "app.routes.feed_routes.add_or_refresh_feed", return_value=existing
+        ), mock.patch("app.routes.feed_routes.Thread"):
+            response = client.post(
+                "/feed",
+                data={"url": "http://example.com/add-nolang.rss"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code in (200, 302)
+        db.session.refresh(existing)
+        assert existing.language is None
+
+
+def test_update_feed_settings_no_fields_returns_400(app):
+    with app.app_context():
+        feed = _make_feed(rss_url="http://example.com/feed4.rss")
+        client = _make_client(app)
+
+        response = client.patch(
+            f"/api/feeds/{feed.id}/settings",
+            json={},
+        )
+
+        assert response.status_code == 400
+        assert "No settings provided" in response.get_json()["error"]

--- a/src/tests/test_feeds.py
+++ b/src/tests/test_feeds.py
@@ -8,10 +8,12 @@ import feedparser
 import PyRSS2Gen
 import pytest
 
+from app.extensions import db
 from app.feeds import (
     _get_base_url,
     _should_auto_whitelist_new_posts,
     add_feed,
+    add_or_refresh_feed,
     db,
     feed_item,
     fetch_feed,
@@ -23,6 +25,7 @@ from app.feeds import (
 )
 from app.models import Feed, Post
 from app.runtime_config import config as runtime_config
+from app.writer.actions.feeds import update_feed_settings_action
 
 logger = logging.getLogger("global_logger")
 
@@ -364,6 +367,41 @@ def test_add_or_refresh_feed_new(
     assert result == mock_feed
 
 
+def test_add_or_refresh_feed_existing_sets_language_before_refresh(app, mock_feed_data):
+    with app.app_context():
+        feed = Feed(title="Existing", rss_url="https://example.com/feed.xml")
+        db.session.add(feed)
+        db.session.commit()
+        mock_feed_data.feed.__contains__.side_effect = lambda key: key == "title"
+        calls: list[str] = []
+
+        def writer_side_effect(action, params, wait=False):
+            calls.append(action)
+            assert action == "update_feed_settings"
+            Feed.query.filter_by(id=params["feed_id"]).update(
+                {"language": params["language"]}
+            )
+            db.session.commit()
+            return SimpleNamespace(success=True, data={"language": params["language"]})
+
+        def refresh_side_effect(refreshed_feed):
+            calls.append("refresh_feed")
+            db.session.refresh(refreshed_feed)
+            assert refreshed_feed.language == "de"
+
+        with (
+            mock.patch("app.feeds.fetch_feed", return_value=mock_feed_data),
+            mock.patch("app.feeds.writer_client") as mock_writer,
+            mock.patch("app.feeds.refresh_feed", side_effect=refresh_side_effect),
+        ):
+            mock_writer.action.side_effect = writer_side_effect
+
+            result = add_or_refresh_feed(feed.rss_url, language="de")
+
+        assert result.id == feed.id
+        assert calls == ["update_feed_settings", "refresh_feed"]
+
+
 @mock.patch("app.feeds.writer_client")
 @mock.patch("app.feeds.Post")
 def test_add_feed(mock_post_class, mock_writer_client, mock_feed_data, mock_db_session):
@@ -404,6 +442,38 @@ def test_add_feed(mock_post_class, mock_writer_client, mock_feed_data, mock_db_s
         mock_writer_client.action.assert_called()
 
         assert result == mock_feed
+
+
+@mock.patch("app.feeds.writer_client")
+@mock.patch("app.feeds.Post")
+def test_add_feed_includes_language_in_writer_payload(
+    mock_post_class, mock_writer_client, mock_feed_data, mock_db_session
+):
+    del mock_post_class
+    mock_writer_client.action.return_value = SimpleNamespace(data={"feed_id": 1})
+
+    with mock.patch("app.feeds.Feed") as mock_feed_class:
+        mock_feed = MockFeed()
+        mock_feed_class.return_value = mock_feed
+        mock_db_session.get.return_value = mock_feed
+
+        mock_feed_data.feed.get = mock.MagicMock()
+        mock_feed_data.feed.get.side_effect = lambda key, default="": {
+            "description": "Test Description",
+            "author": "Test Author",
+        }.get(key, default)
+
+        with mock.patch("app.feeds.config") as mock_config:
+            mock_config.number_of_episodes_to_whitelist_from_archive_of_new_feed = 1
+            mock_config.automatically_whitelist_new_episodes = True
+            with mock.patch("app.feeds.make_post") as mock_make_post:
+                mock_make_post.return_value = MockPost()
+
+                add_feed(mock_feed_data, language="de")
+
+        action_name, payload = mock_writer_client.action.call_args.args[:2]
+        assert action_name == "add_feed"
+        assert payload["feed"]["language"] == "de"
 
 
 def test_feed_item(mock_post, app):
@@ -895,3 +965,41 @@ def test_get_base_url_fallback_http_without_sts():
 
     # Should use HTTP when no HTTPS indicators present
     assert result == "http://insecure.example.com"
+
+
+def test_feed_language_defaults_to_none(app):
+    with app.app_context():
+        feed = Feed(title="Test", rss_url="http://example.com/feed.rss")
+        db.session.add(feed)
+        db.session.flush()
+        assert feed.language is None
+
+
+def test_feed_language_can_be_set(app):
+    with app.app_context():
+        feed = Feed(title="Test", rss_url="http://example.com/feed2.rss", language="de")
+        db.session.add(feed)
+        db.session.flush()
+        assert feed.language == "de"
+
+
+def test_update_feed_settings_action_sets_language(app):
+    with app.app_context():
+        feed = Feed(title="Test", rss_url="http://example.com/feed3.rss")
+        db.session.add(feed)
+        db.session.commit()
+
+        update_feed_settings_action({"feed_id": feed.id, "language": "fr"})
+        db.session.refresh(feed)
+        assert feed.language == "fr"
+
+
+def test_update_feed_settings_action_clears_language(app):
+    with app.app_context():
+        feed = Feed(title="Test", rss_url="http://example.com/feed4.rss", language="fr")
+        db.session.add(feed)
+        db.session.commit()
+
+        update_feed_settings_action({"feed_id": feed.id, "language": None})
+        db.session.refresh(feed)
+        assert feed.language is None

--- a/src/tests/test_processor_action.py
+++ b/src/tests/test_processor_action.py
@@ -1,0 +1,193 @@
+"""Focused tests for replace_transcription_action's cache invalidation."""
+
+from app.extensions import db
+from app.models import Feed, ModelCall, Post
+from app.writer.actions.processor import replace_transcription_action
+
+
+def _make_post(app, *, guid="guid-1"):
+    feed = Feed(title="T", rss_url=f"http://example.com/{guid}.rss")
+    post = Post(
+        feed=feed,
+        guid=guid,
+        download_url=f"http://example.com/{guid}.mp3",
+        title=guid,
+        unprocessed_audio_path=f"/tmp/{guid}.mp3",
+    )
+    db.session.add_all([feed, post])
+    db.session.commit()
+    return post
+
+
+def test_replace_transcription_supersedes_sibling_whisper_calls(app):
+    """A finished whisper run in one language marks prior-language whisper rows superseded."""
+    with app.app_context():
+        post = _make_post(app, guid="supersede")
+
+        en_call = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=0,
+            prompt="x",
+            language="en",
+            status="success",
+        )
+        de_call = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=-1,
+            prompt="x",
+            language="de",
+            status="pending",
+        )
+        db.session.add_all([en_call, de_call])
+        db.session.commit()
+
+        replace_transcription_action(
+            {
+                "post_id": post.id,
+                "segments": [
+                    {
+                        "sequence_num": 0,
+                        "start_time": 0.0,
+                        "end_time": 1.0,
+                        "text": "Hallo",
+                    }
+                ],
+                "model_call_id": de_call.id,
+            }
+        )
+        db.session.commit()
+
+        db.session.refresh(en_call)
+        db.session.refresh(de_call)
+        assert en_call.status == "superseded"
+        assert de_call.status == "success"
+
+
+def test_replace_transcription_deletes_llm_when_supersede_fires(app):
+    """A real language change supersedes a sibling whisper row AND wipes LLM caches."""
+    with app.app_context():
+        post = _make_post(app, guid="llm-clear")
+
+        prior_whisper = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=0,
+            prompt="x",
+            language="en",
+            status="success",
+        )
+        llm_call = ModelCall(
+            post_id=post.id,
+            model_name="gpt-5-mini",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=29,
+            prompt="ad classifier prompt built from English transcript",
+            response="prior response",
+            language=None,
+            status="success",
+        )
+        new_whisper = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=-1,
+            prompt="Whisper transcription job",
+            language="de",
+            status="pending",
+        )
+        db.session.add_all([prior_whisper, llm_call, new_whisper])
+        db.session.commit()
+        llm_id = llm_call.id
+
+        replace_transcription_action(
+            {
+                "post_id": post.id,
+                "segments": [
+                    {
+                        "sequence_num": 0,
+                        "start_time": 0.0,
+                        "end_time": 1.0,
+                        "text": "neu",
+                    }
+                ],
+                "model_call_id": new_whisper.id,
+            }
+        )
+        db.session.commit()
+
+        # Language actually changed: LLM cache is invalidated.
+        assert db.session.get(ModelCall, llm_id) is None
+        db.session.refresh(prior_whisper)
+        assert prior_whisper.status == "superseded"
+
+
+def test_replace_transcription_preserves_llm_when_no_sibling_to_supersede(app):
+    """First post-migration transcription: legacy whisper row has language=NULL,
+    so the supersede filter matches zero rows. We must NOT delete the LLM
+    cache in this case — otherwise every previously-processed post pays an
+    LLM re-classification cost on the first run after upgrade."""
+    with app.app_context():
+        post = _make_post(app, guid="legacy-llm")
+
+        # Legacy whisper row from before the language column existed.
+        legacy_whisper = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=0,
+            prompt="x",
+            language=None,
+            status="success",
+        )
+        # Existing LLM ad-classifier cache — built against the legacy
+        # transcript text but still useful for the current segments.
+        llm_call = ModelCall(
+            post_id=post.id,
+            model_name="gpt-5-mini",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=29,
+            prompt="ad classifier prompt",
+            response="cached classification",
+            language=None,
+            status="success",
+        )
+        new_whisper = ModelCall(
+            post_id=post.id,
+            model_name="whisper-1",
+            first_segment_sequence_num=0,
+            last_segment_sequence_num=-1,
+            prompt="Whisper transcription job",
+            language="en",
+            status="pending",
+        )
+        db.session.add_all([legacy_whisper, llm_call, new_whisper])
+        db.session.commit()
+        llm_id = llm_call.id
+
+        replace_transcription_action(
+            {
+                "post_id": post.id,
+                "segments": [
+                    {
+                        "sequence_num": 0,
+                        "start_time": 0.0,
+                        "end_time": 1.0,
+                        "text": "hi",
+                    }
+                ],
+                "model_call_id": new_whisper.id,
+            }
+        )
+        db.session.commit()
+
+        # Legacy NULL-language whisper isn't matched by the supersede filter
+        # (which requires language IS NOT NULL), so the supersede count is 0
+        # and the LLM cache survives untouched.
+        assert db.session.get(ModelCall, llm_id) is not None
+        db.session.refresh(llm_call)
+        assert llm_call.status == "success"

--- a/src/tests/test_transcription_manager.py
+++ b/src/tests/test_transcription_manager.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Generator
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -25,7 +25,7 @@ class MockTranscriber(Transcriber):
         """Implementation of the abstract property"""
         return self._model_name
 
-    def transcribe(self, audio_path):
+    def transcribe(self, audio_path, language=None):
         """Return mock segments or raise exception based on configuration."""
         if isinstance(self.mock_response, Exception):
             raise self.mock_response
@@ -131,12 +131,10 @@ def test_check_existing_transcription_success(
 
     with app.app_context():
         # Configure the existing mocks in the manager
-        test_manager.model_call_query.filter_by().order_by().first.return_value = (
-            model_call
-        )
+        test_manager.model_call_query.filter_by().one_or_none.return_value = model_call
         test_manager.segment_query.filter_by().order_by().all.return_value = segments
 
-        result = test_manager._check_existing_transcription(post)
+        result = test_manager._check_existing_transcription(post, "en")
 
         assert result is not None
         assert len(result) == 2
@@ -153,9 +151,9 @@ def test_check_existing_transcription_no_model_call(
 
     with app.app_context():
         # Set return value for the existing mock in the manager
-        test_manager.model_call_query.filter_by().order_by().first.return_value = None
+        test_manager.model_call_query.filter_by().one_or_none.return_value = None
 
-        result = test_manager._check_existing_transcription(post)
+        result = test_manager._check_existing_transcription(post, "en")
         assert result is None
 
 
@@ -268,6 +266,7 @@ def test_transcribe_reuses_placeholder_model_call(
             last_segment_sequence_num=-1,
             prompt="Whisper transcription job",
             status="failed_permanent",
+            language="en",
         )
         db.session.add(existing_call)
         db.session.commit()
@@ -292,3 +291,105 @@ def test_transcribe_reuses_placeholder_model_call(
         assert refreshed_call.id == existing_call.id
         assert refreshed_call.status == "success"
         assert refreshed_call.last_segment_sequence_num == 1
+
+
+def test_transcribe_passes_language_to_transcriber(
+    test_config: Config,
+    test_logger: logging.Logger,
+    mock_db_session: MagicMock,
+    app: Flask,
+) -> None:
+    """Language is forwarded to the underlying transcriber."""
+    post = Post(id=99, title="Test Post", unprocessed_audio_path="/path/to/audio.mp3")
+
+    dummy_call = ModelCall(
+        id=1,
+        post_id=99,
+        model_name="mock_transcriber",
+        status="placeholder",
+        first_segment_sequence_num=0,
+        last_segment_sequence_num=-1,
+    )
+
+    mock_model_call_query = MagicMock()
+    mock_model_call_query.filter_by().one_or_none.return_value = None
+    mock_db_session.execute.return_value = MagicMock(lastrowid=1)
+    mock_db_session.get.return_value = dummy_call
+
+    mock_segment_query = MagicMock()
+    mock_segment_query.filter_by().order_by().all.return_value = []
+
+    segments_out = [Segment(start=0.0, end=1.0, text="Hallo")]
+    transcriber = MockTranscriber(segments_out)
+
+    with app.app_context():
+        manager = TranscriptionManager(
+            test_logger,
+            test_config,
+            model_call_query=mock_model_call_query,
+            segment_query=mock_segment_query,
+            db_session=mock_db_session,
+            transcriber=transcriber,
+        )
+
+        with patch.object(
+            transcriber, "transcribe", wraps=transcriber.transcribe
+        ) as mock_transcribe:
+            manager.transcribe(post, language="de")
+            mock_transcribe.assert_called_once_with(
+                post.unprocessed_audio_path, language="de"
+            )
+
+
+def test_language_change_invalidates_cache(
+    test_config: Config,
+    test_logger: logging.Logger,
+    app: Flask,
+) -> None:
+    """Changing the per-feed language forces a fresh transcription instead of returning
+    the cached transcript from the prior language."""
+    with app.app_context():
+        feed = Feed(title="Test Feed", rss_url="http://example.com/rss.xml")
+        post = Post(
+            feed=feed,
+            guid="guid-lang",
+            download_url="http://example.com/audio.mp3",
+            title="Test Post",
+            unprocessed_audio_path="/path/to/audio.mp3",
+        )
+        db.session.add_all([feed, post])
+        db.session.commit()
+
+        en_transcript = [Segment(start=0.0, end=1.0, text="English")]
+        en_manager = TranscriptionManager(
+            test_logger,
+            test_config,
+            db_session=db.session,
+            transcriber=MockTranscriber(en_transcript),
+        )
+        en_result = en_manager.transcribe(post, language="en")
+        assert [s.text for s in en_result] == ["English"]
+        assert ModelCall.query.filter_by(post_id=post.id).count() == 1
+
+        de_transcript = [Segment(start=0.0, end=1.0, text="Deutsch")]
+        de_manager = TranscriptionManager(
+            test_logger,
+            test_config,
+            db_session=db.session,
+            transcriber=MockTranscriber(de_transcript),
+        )
+        de_result = de_manager.transcribe(post, language="de")
+        assert [s.text for s in de_result] == ["Deutsch"]
+        # Two ModelCall rows — one per language — so the en cache wasn't returned.
+        en_call = ModelCall.query.filter_by(post_id=post.id, language="en").one()
+        de_call = ModelCall.query.filter_by(post_id=post.id, language="de").one()
+        # The de transcription overwrote the shared segments table, so the en
+        # row must be marked superseded — otherwise a later en lookup would
+        # return de segments labeled as English.
+        assert en_call.status == "superseded"
+        assert de_call.status == "success"
+
+        # Re-running with the original language must re-transcribe (cache miss
+        # because the en row is superseded) — returns English from the mock.
+        en_again = en_manager.transcribe(post, language="en")
+        assert [s.text for s in en_again] == ["English"]


### PR DESCRIPTION
- fixes https://github.com/podly-pure-podcasts/podly_pure_podcasts/issues/75

👋  Human here! This PR adds support for per podcast language settings. I have been running this code locally for a while and it solves the problem e.g. that german podcasts are not transcribed correctly. The changes in this PR have been validated by multiple AI agents and myself. Please consider merging them as it might be helpful for others too :) 

## TL;DR

- Adds a per-feed Whisper language override (NULL = inherit the existing global Whisper setting).
- Stores ISO 639-1 codes (`en`, `de`, …) so values flow through to LLM APIs without translation.
- Changing a feed's language now invalidates its cached transcript so the next run actually re-transcribes.


<img width="1975" height="476" alt="Screenshot 2026-05-19 at 15 43 31" src="https://github.com/user-attachments/assets/830f35c5-846f-4bf9-b2ab-4a0f3f6a5277" />
<img width="810" height="443" alt="Screenshot 2026-05-19 at 15 49 41" src="https://github.com/user-attachments/assets/5a6e25b4-acdb-4c56-ba4d-4e2d3bac1753" />
<img width="535" height="232" alt="Screenshot 2026-05-19 at 15 49 46" src="https://github.com/user-attachments/assets/4042e18f-3bdd-4f94-b2ab-1a980f0e80fd" />



## Why

Whisper auto-detect can misclassify episodes that open with a foreign-language ad (e.g. a German podcast with an English intro ad). The existing global Whisper language setting applies one default across every feed, with no way to override on a per-feed basis.

## How it works

- `Feed.language` is nullable. NULL = inherit the global Whisper language (`RemoteWhisperConfig.language` / `GroqWhisperConfig.language`, admin-configurable). A specific ISO 639-1 code overrides it.
- Frontend dropdown shows "Use global setting" plus 17 specific languages.
- For users who don't touch the new setting, behavior is unchanged.

## Cache invalidation

Transcripts were previously keyed on `(post, model_name, status=success)` only — switching a feed's language would silently return the old transcript. Now:

- `ModelCall` has a `language` column.
- Whisper rows: partial unique index on `(post, model_name, language)`. Legacy / LLM rows (NULL language) keep the original chunk-based unique index. Two partial indexes via `sqlite_where`.
- `replace_transcription` marks sibling whisper `ModelCall` rows as `superseded` whenever new segments overwrite the shared segments table.

## Changes

- **DB**: nullable `Feed.language` (`35adef5e4c3e`); nullable `ModelCall.language` + two partial unique indexes (`a7c1b9e2d4f5`).
- **API**: `PATCH /api/feeds/<id>/settings` accepts `language` (ISO code or null); rejects non-strings and invalid codes with 400.
- **Transcription pipeline**: `TranscriptionManager._effective_language` resolves per-feed override → global config → `"en"`. Transcribers take `language: str`.
- **Frontend**: language dropdown beside auto-whitelist; admin feed settings lay out side-by-side at `sm:` and up.

## Backwards compatibility

- Existing `Feed` rows: `language` defaults to NULL = inherit global. No behavior change unless an admin sets a per-feed value.
- Existing `ModelCall` rows: `language` defaults to NULL. First re-process of each post after upgrade re-transcribes once (NULL doesn't match the new effective language). After that, cache hits resume normally.
